### PR TITLE
fix: model with nested & allOf missing imports

### DIFF
--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -59,6 +59,7 @@ def cli(specs, output):
     env.globals["get_container"] = openapi.get_container
     env.globals["get_container_type"] = openapi.get_container_type
     env.globals["get_type_at_path"] = openapi.get_type_at_path
+    env.globals["get_model_imports"] = openapi.get_model_imports
     env.globals["common_package_name"] = COMMON_PACKAGE_NAME
     env.globals["module"] = MODULE
 

--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -112,6 +112,7 @@ def format_value(value, quotes='"', schema=None):
         index = schema["enum"].index(value)
         enum_varname = get_enum_varname(schema, index)
         name = schema_name(schema)
+        # Include the type name to make constants unique
         return f"{upperfirst(name)}{enum_varname}"
 
     if isinstance(value, str):
@@ -153,7 +154,7 @@ def simple_type(schema, render_nullable=False, render_new=False):
     if type_name == "number":
         return {
             "double": "float64" if not nullable else f"{nullable_prefix}Float64",
-            None: "float" if not nullable else f"{nullable_prefix}Float",
+            None: "float64" if not nullable else f"{nullable_prefix}Float64",
         }[type_format]
 
     if type_name == "string":
@@ -180,7 +181,8 @@ def is_reference(schema, attribute):
     if attribute_schema == {} and schema.get("allOf") is not None:
         for obj in schema["allOf"]:
             if attribute in obj.get("properties", {}):
-                return is_reference(obj, attribute)
+                attribute_schema = obj["properties"][attribute]
+                break
 
     is_nullable = attribute_schema.get("nullable", False)
     if is_nullable:

--- a/.generator/src/generator/templates/model.j2
+++ b/.generator/src/generator/templates/model.j2
@@ -1,14 +1,15 @@
 {% include "partial_header.j2" %}
 package {{ package_name }}
 
+{%- set model_imports = get_model_imports(model, package_name) %}
 import (
 	"github.com/google/uuid"
 	"fmt"
 
 	"github.com/apecloud/kb-cloud-client-go/api"
-{#imports
-	"{{import}}"
-#}
+{%- for import_path in model_imports %}
+	"{{ import_path }}"
+{%- endfor %}
 )
 
 {# {{ model.description.rstrip()|replace('\n', '\n# ')|indent(2) }}#}

--- a/.generator/src/generator/templates/model_enum.j2
+++ b/.generator/src/generator/templates/model_enum.j2
@@ -6,13 +6,13 @@ type {{ name }} {{ model|simple_type }}
 // List of {{ name }}.
 const (
 	{%- for index, value in enumerate(model.enum) %}
-	{{ value|format_value(schema=model) }} {{ name }} = {{ value|format_value }}
+	{{ name }}{{ value|format_value(schema=model)|replace(name, "")|replace("None", "") }} {{ name }} = {{ value|format_value }}
 {%- endfor %}
 )
 
 var allowed{{ name }}EnumValues = []{{ name }}{
 	{%- for index, value in enumerate(model.enum) %}
-	{{ value|format_value(schema=model) }},
+	{{ name }}{{ value|format_value(schema=model)|replace(name, "")|replace("None", "") }},
 	{%- endfor %}
 }
 

--- a/.generator/src/generator/templates/model_simple.j2
+++ b/.generator/src/generator/templates/model_simple.j2
@@ -328,6 +328,8 @@ func (o *{{ name }}) UnmarshalJSON(bytes []byte) (err error) {
 	}
 
 	{%- if not isPrimitiveContainer %}
+	{%- set itemsType = get_type(model.get("items", {}), alternative_name=name + "Item") %}
+	{%- if itemsType not in ["interface{}", "map[string]interface{}"] and not itemsType.startswith("[]") and not itemsType.startswith("map[") %}
 
 	if o.Items != nil && len(o.Items) > 0 {
 		for _, v := range o.Items {
@@ -336,6 +338,7 @@ func (o *{{ name }}) UnmarshalJSON(bytes []byte) (err error) {
 			}
 		}
 	}
+	{%- endif %}
 	{%- endif %}
 
 	return nil

--- a/.generator/src/generator/utils.py
+++ b/.generator/src/generator/utils.py
@@ -24,6 +24,10 @@ def safe_snake_case(value):
 
 
 def upperfirst(value):
+    if value is None:
+        return None
+    if len(value) == 0:
+        return value
     return value[0].upper() + value[1:]
 
 

--- a/api/kbcloud/admin/model_account_list.go
+++ b/api/kbcloud/admin/model_account_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type AccountList struct {
+	Items []AccountListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewAccountList instantiates a new AccountList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewAccountList() *AccountList {
+	this := AccountList{}
+	return &this
+}
+
+// NewAccountListWithDefaults instantiates a new AccountList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewAccountListWithDefaults() *AccountList {
+	this := AccountList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o AccountList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *AccountList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_autohealing_list.go
+++ b/api/kbcloud/admin/model_autohealing_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// AutohealingList An Autohealing object in k8s
+type AutohealingList struct {
+	Items []AutohealingListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewAutohealingList instantiates a new AutohealingList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewAutohealingList() *AutohealingList {
+	this := AutohealingList{}
+	return &this
+}
+
+// NewAutohealingListWithDefaults instantiates a new AutohealingList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewAutohealingListWithDefaults() *AutohealingList {
+	this := AutohealingList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o AutohealingList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *AutohealingList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_available_cluster_list.go
+++ b/api/kbcloud/admin/model_available_cluster_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type AvailableClusterList struct {
+	Items []AvailableClusterListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewAvailableClusterList instantiates a new AvailableClusterList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewAvailableClusterList() *AvailableClusterList {
+	this := AvailableClusterList{}
+	return &this
+}
+
+// NewAvailableClusterListWithDefaults instantiates a new AvailableClusterList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewAvailableClusterListWithDefaults() *AvailableClusterList {
+	this := AvailableClusterList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o AvailableClusterList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *AvailableClusterList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_bill.go
+++ b/api/kbcloud/admin/model_bill.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // Bill Task information
 type Bill struct {

--- a/api/kbcloud/admin/model_broker_list.go
+++ b/api/kbcloud/admin/model_broker_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type BrokerList struct {
+	Items []Broker
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewBrokerList instantiates a new BrokerList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewBrokerList() *BrokerList {
+	this := BrokerList{}
+	return &this
+}
+
+// NewBrokerListWithDefaults instantiates a new BrokerList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewBrokerListWithDefaults() *BrokerList {
+	this := BrokerList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o BrokerList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *BrokerList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_cdc_cluster_endpoint.go
+++ b/api/kbcloud/admin/model_cdc_cluster_endpoint.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcClusterEndpoint struct {
 	Role         *string               `json:"role,omitempty"`

--- a/api/kbcloud/admin/model_cdc_lifecycle.go
+++ b/api/kbcloud/admin/model_cdc_lifecycle.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcLifecycle struct {
 	PreStart  *CdcLifecycleAction `json:"preStart,omitempty"`

--- a/api/kbcloud/admin/model_cdc_lifecycle_action.go
+++ b/api/kbcloud/admin/model_cdc_lifecycle_action.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcLifecycleAction struct {
 	Name        *string         `json:"name,omitempty"`

--- a/api/kbcloud/admin/model_cdc_option.go
+++ b/api/kbcloud/admin/model_cdc_option.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcOption struct {
 	Versions []string           `json:"versions,omitempty"`

--- a/api/kbcloud/admin/model_cdc_settings.go
+++ b/api/kbcloud/admin/model_cdc_settings.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcSettings struct {
 	Config    *CdcClusterConfig   `json:"config,omitempty"`

--- a/api/kbcloud/admin/model_cdc_sql_executor.go
+++ b/api/kbcloud/admin/model_cdc_sql_executor.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcSqlExecutor struct {
 	Sql          []string              `json:"sql,omitempty"`

--- a/api/kbcloud/admin/model_cdc_tool_template.go
+++ b/api/kbcloud/admin/model_cdc_tool_template.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcToolTemplate struct {
 	Image              *string                `json:"image,omitempty"`

--- a/api/kbcloud/admin/model_cdc_worker_template.go
+++ b/api/kbcloud/admin/model_cdc_worker_template.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcWorkerTemplate struct {
 	UsingTool *CdcToolTemplate `json:"usingTool,omitempty"`

--- a/api/kbcloud/admin/model_cluster_backup.go
+++ b/api/kbcloud/admin/model_cluster_backup.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterBackup clusterBackup is the payload for cluster backup
 type ClusterBackup struct {

--- a/api/kbcloud/admin/model_cluster_metrics.go
+++ b/api/kbcloud/admin/model_cluster_metrics.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterMetrics Cluster metrics
 type ClusterMetrics struct {

--- a/api/kbcloud/admin/model_cluster_task_list.go
+++ b/api/kbcloud/admin/model_cluster_task_list.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterTaskList TaskList is a list of operation task objects
 type ClusterTaskList struct {

--- a/api/kbcloud/admin/model_cluster_task_progresses.go
+++ b/api/kbcloud/admin/model_cluster_task_progresses.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterTaskProgresses clusterTaskProgresses is a list of task progress detail
 type ClusterTaskProgresses struct {

--- a/api/kbcloud/admin/model_cluster_update.go
+++ b/api/kbcloud/admin/model_cluster_update.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterUpdate ClusterUpdate is the payload to update a KubeBlocks cluster
 type ClusterUpdate struct {

--- a/api/kbcloud/admin/model_component_item.go
+++ b/api/kbcloud/admin/model_component_item.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ComponentItem ComponentItem is the information of a component
 type ComponentItem struct {

--- a/api/kbcloud/admin/model_component_volume_item.go
+++ b/api/kbcloud/admin/model_component_volume_item.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ComponentVolumeItem ComponentVolumeItem is the information of a component volume
 type ComponentVolumeItem struct {

--- a/api/kbcloud/admin/model_components.go
+++ b/api/kbcloud/admin/model_components.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+// Components Components is the list of components
+type Components struct {
+	Items []ComponentItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewComponents instantiates a new Components object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewComponents() *Components {
+	this := Components{}
+	return &this
+}
+
+// NewComponentsWithDefaults instantiates a new Components object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewComponentsWithDefaults() *Components {
+	this := Components{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o Components) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *Components) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_components_create.go
+++ b/api/kbcloud/admin/model_components_create.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+// ComponentsCreate Components is the list of components
+type ComponentsCreate struct {
+	Items []ComponentItemCreate
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewComponentsCreate instantiates a new ComponentsCreate object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewComponentsCreate() *ComponentsCreate {
+	this := ComponentsCreate{}
+	return &this
+}
+
+// NewComponentsCreateWithDefaults instantiates a new ComponentsCreate object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewComponentsCreateWithDefaults() *ComponentsCreate {
+	this := ComponentsCreate{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ComponentsCreate) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ComponentsCreate) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_config_list.go
+++ b/api/kbcloud/admin/model_config_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type ConfigList struct {
+	Items []ConfigEntry
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewConfigList instantiates a new ConfigList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewConfigList() *ConfigList {
+	this := ConfigList{}
+	return &this
+}
+
+// NewConfigListWithDefaults instantiates a new ConfigList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewConfigListWithDefaults() *ConfigList {
+	this := ConfigList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ConfigList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ConfigList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_consumer_group_describe_response.go
+++ b/api/kbcloud/admin/model_consumer_group_describe_response.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type ConsumerGroupDescribeResponse struct {
+	Items []ConsumerGroupDescribe
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewConsumerGroupDescribeResponse instantiates a new ConsumerGroupDescribeResponse object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewConsumerGroupDescribeResponse() *ConsumerGroupDescribeResponse {
+	this := ConsumerGroupDescribeResponse{}
+	return &this
+}
+
+// NewConsumerGroupDescribeResponseWithDefaults instantiates a new ConsumerGroupDescribeResponse object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewConsumerGroupDescribeResponseWithDefaults() *ConsumerGroupDescribeResponse {
+	this := ConsumerGroupDescribeResponse{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ConsumerGroupDescribeResponse) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ConsumerGroupDescribeResponse) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_consumer_group_list.go
+++ b/api/kbcloud/admin/model_consumer_group_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type ConsumerGroupList struct {
+	Items []ConsumerGroup
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewConsumerGroupList instantiates a new ConsumerGroupList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewConsumerGroupList() *ConsumerGroupList {
+	this := ConsumerGroupList{}
+	return &this
+}
+
+// NewConsumerGroupListWithDefaults instantiates a new ConsumerGroupList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewConsumerGroupListWithDefaults() *ConsumerGroupList {
+	this := ConsumerGroupList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ConsumerGroupList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ConsumerGroupList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_data_replication_option.go
+++ b/api/kbcloud/admin/model_data_replication_option.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DataReplicationOption struct {
 	ModuleDefinitions []ModuleDefinition   `json:"moduleDefinitions,omitempty"`

--- a/api/kbcloud/admin/model_datasource_list.go
+++ b/api/kbcloud/admin/model_datasource_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DatasourceList struct {
+	Items []Datasource
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDatasourceList instantiates a new DatasourceList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDatasourceList() *DatasourceList {
+	this := DatasourceList{}
+	return &this
+}
+
+// NewDatasourceListWithDefaults instantiates a new DatasourceList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDatasourceListWithDefaults() *DatasourceList {
+	this := DatasourceList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DatasourceList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DatasourceList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dm_tablespace_list.go
+++ b/api/kbcloud/admin/model_dm_tablespace_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// DmTablespaceList the list of tablespace
+type DmTablespaceList struct {
+	Items []DmTablespace
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmTablespaceList instantiates a new DmTablespaceList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmTablespaceList() *DmTablespaceList {
+	this := DmTablespaceList{}
+	return &this
+}
+
+// NewDmTablespaceListWithDefaults instantiates a new DmTablespaceList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmTablespaceListWithDefaults() *DmTablespaceList {
+	this := DmTablespaceList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmTablespaceList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmTablespaceList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dms_exclude_constraint.go
+++ b/api/kbcloud/admin/model_dms_exclude_constraint.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsExcludeConstraint struct {
 	// The name of the exclude constraint

--- a/api/kbcloud/admin/model_dms_foreign_key.go
+++ b/api/kbcloud/admin/model_dms_foreign_key.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsForeignKey struct {
 	// The name of the foreign key

--- a/api/kbcloud/admin/model_dms_foreign_key_reference.go
+++ b/api/kbcloud/admin/model_dms_foreign_key_reference.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // DmsForeignKeyReference The reference details of the foreign key
 type DmsForeignKeyReference struct {

--- a/api/kbcloud/admin/model_dms_object_list.go
+++ b/api/kbcloud/admin/model_dms_object_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsObjectList struct {
+	Items []DmsObject
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsObjectList instantiates a new DmsObjectList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsObjectList() *DmsObjectList {
+	this := DmsObjectList{}
+	return &this
+}
+
+// NewDmsObjectListWithDefaults instantiates a new DmsObjectList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsObjectListWithDefaults() *DmsObjectList {
+	this := DmsObjectList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsObjectList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsObjectList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dms_object_name_list.go
+++ b/api/kbcloud/admin/model_dms_object_name_list.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsObjectNameList struct {
+	Items []string
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsObjectNameList instantiates a new DmsObjectNameList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsObjectNameList() *DmsObjectNameList {
+	this := DmsObjectNameList{}
+	return &this
+}
+
+// NewDmsObjectNameListWithDefaults instantiates a new DmsObjectNameList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsObjectNameListWithDefaults() *DmsObjectNameList {
+	this := DmsObjectNameList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsObjectNameList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsObjectNameList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dms_parameter_list.go
+++ b/api/kbcloud/admin/model_dms_parameter_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsParameterList struct {
+	Items []DmsObParameter
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsParameterList instantiates a new DmsParameterList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsParameterList() *DmsParameterList {
+	this := DmsParameterList{}
+	return &this
+}
+
+// NewDmsParameterListWithDefaults instantiates a new DmsParameterList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsParameterListWithDefaults() *DmsParameterList {
+	this := DmsParameterList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsParameterList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsParameterList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dms_primary_key.go
+++ b/api/kbcloud/admin/model_dms_primary_key.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsPrimaryKey struct {
 	// The name of the primary key

--- a/api/kbcloud/admin/model_dms_query_history_list.go
+++ b/api/kbcloud/admin/model_dms_query_history_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsQueryHistoryList struct {
+	Items []DmsQueryHistory
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsQueryHistoryList instantiates a new DmsQueryHistoryList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsQueryHistoryList() *DmsQueryHistoryList {
+	this := DmsQueryHistoryList{}
+	return &this
+}
+
+// NewDmsQueryHistoryListWithDefaults instantiates a new DmsQueryHistoryList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsQueryHistoryListWithDefaults() *DmsQueryHistoryList {
+	this := DmsQueryHistoryList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsQueryHistoryList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsQueryHistoryList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dms_query_request.go
+++ b/api/kbcloud/admin/model_dms_query_request.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsQueryRequest struct {
 	// the database of the table or view

--- a/api/kbcloud/admin/model_dms_query_response.go
+++ b/api/kbcloud/admin/model_dms_query_response.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsQueryResponse struct {
 	// result set of query

--- a/api/kbcloud/admin/model_dms_row.go
+++ b/api/kbcloud/admin/model_dms_row.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsRow struct {
+	Items []interface{}
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsRow instantiates a new DmsRow object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsRow() *DmsRow {
+	this := DmsRow{}
+	return &this
+}
+
+// NewDmsRowWithDefaults instantiates a new DmsRow object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsRowWithDefaults() *DmsRow {
+	this := DmsRow{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsRow) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsRow) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dms_schema_list.go
+++ b/api/kbcloud/admin/model_dms_schema_list.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsSchemaList struct {
+	Items []string
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsSchemaList instantiates a new DmsSchemaList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsSchemaList() *DmsSchemaList {
+	this := DmsSchemaList{}
+	return &this
+}
+
+// NewDmsSchemaListWithDefaults instantiates a new DmsSchemaList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsSchemaListWithDefaults() *DmsSchemaList {
+	this := DmsSchemaList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsSchemaList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsSchemaList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dms_session_list.go
+++ b/api/kbcloud/admin/model_dms_session_list.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type DmsSessionList struct {
+	Items []DmsSession
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsSessionList instantiates a new DmsSessionList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsSessionList() *DmsSessionList {
+	this := DmsSessionList{}
+	return &this
+}
+
+// NewDmsSessionListWithDefaults instantiates a new DmsSessionList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsSessionListWithDefaults() *DmsSessionList {
+	this := DmsSessionList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsSessionList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsSessionList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_dms_table_column.go
+++ b/api/kbcloud/admin/model_dms_table_column.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTableColumn struct {
 	// The name of the column

--- a/api/kbcloud/admin/model_dms_table_column_generated.go
+++ b/api/kbcloud/admin/model_dms_table_column_generated.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // DmsTableColumnGenerated Generated column information
 type DmsTableColumnGenerated struct {

--- a/api/kbcloud/admin/model_dms_table_index.go
+++ b/api/kbcloud/admin/model_dms_table_index.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTableIndex struct {
 	// The name of the index

--- a/api/kbcloud/admin/model_dms_table_metadata.go
+++ b/api/kbcloud/admin/model_dms_table_metadata.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTableMetadata struct {
 	// The name of the table

--- a/api/kbcloud/admin/model_dms_table_options.go
+++ b/api/kbcloud/admin/model_dms_table_options.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTableOptions struct {
 	// The storage engine for the table

--- a/api/kbcloud/admin/model_dms_task_list.go
+++ b/api/kbcloud/admin/model_dms_task_list.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTaskList struct {
 	Tasks []DmsTaskInfo `json:"tasks,omitempty"`

--- a/api/kbcloud/admin/model_dms_unique_key.go
+++ b/api/kbcloud/admin/model_dms_unique_key.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsUniqueKey struct {
 	// The name of the unique key

--- a/api/kbcloud/admin/model_dms_view_metadata.go
+++ b/api/kbcloud/admin/model_dms_view_metadata.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsViewMetadata struct {
 	// The name of the view

--- a/api/kbcloud/admin/model_engine_action_type.go
+++ b/api/kbcloud/admin/model_engine_action_type.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import (
+	"fmt"
+
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+// EngineActionType engine action type
+type EngineActionType string
+
+// List of EngineActionType.
+const (
+	EngineActionTypeEnable  EngineActionType = "enable"
+	EngineActionTypeDisable EngineActionType = "disable"
+	EngineActionTypeUpgrade EngineActionType = "upgrade"
+)
+
+var allowedEngineActionTypeEnumValues = []EngineActionType{
+	EngineActionTypeEnable,
+	EngineActionTypeDisable,
+	EngineActionTypeUpgrade,
+}
+
+// GetAllowedValues returns the list of possible values.
+func (v *EngineActionType) GetAllowedValues() []EngineActionType {
+	return allowedEngineActionTypeEnumValues
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (v *EngineActionType) UnmarshalJSON(src []byte) error {
+	var value string
+	err := common.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	*v = EngineActionType(value)
+	return nil
+}
+
+// NewEngineActionTypeFromValue returns a pointer to a valid EngineActionType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum.
+func NewEngineActionTypeFromValue(v string) (*EngineActionType, error) {
+	ev := EngineActionType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	}
+	return nil, fmt.Errorf("invalid value '%v' for EngineActionType: valid values are %v", v, allowedEngineActionTypeEnumValues)
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise.
+func (v EngineActionType) IsValid() bool {
+	for _, existing := range allowedEngineActionTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Ptr returns reference to EngineActionType value.
+func (v EngineActionType) Ptr() *EngineActionType {
+	return &v
+}

--- a/api/kbcloud/admin/model_engine_definition.go
+++ b/api/kbcloud/admin/model_engine_definition.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type EngineDefinition struct {
 	Name       *string                 `json:"name,omitempty"`

--- a/api/kbcloud/admin/model_engine_definition_detail.go
+++ b/api/kbcloud/admin/model_engine_definition_detail.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type EngineDefinitionDetail struct {
 	DefinitionName *string `json:"definitionName,omitempty"`

--- a/api/kbcloud/admin/model_engine_definition_version.go
+++ b/api/kbcloud/admin/model_engine_definition_version.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type EngineDefinitionVersion struct {
 	Version common.NullableString         `json:"version,omitempty"`

--- a/api/kbcloud/admin/model_engine_definition_version_query.go
+++ b/api/kbcloud/admin/model_engine_definition_version_query.go
@@ -4,13 +4,17 @@
 
 package admin
 
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
 type EngineDefinitionVersionQuery struct {
 	// the query to get the version, if not provided, will use inherited query from engine definition
-	Sql    common.NullableString `json:"sql,omitempty"`
-	Column common.NullableString `json:"column,omitempty"`
-	Regex  common.NullableString `json:"regex,omitempty"`
-	Min    common.NullableFloat  `json:"min,omitempty"`
-	Max    common.NullableFloat  `json:"max,omitempty"`
+	Sql    common.NullableString  `json:"sql,omitempty"`
+	Column common.NullableString  `json:"column,omitempty"`
+	Regex  common.NullableString  `json:"regex,omitempty"`
+	Min    common.NullableFloat64 `json:"min,omitempty"`
+	Max    common.NullableFloat64 `json:"max,omitempty"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
 	UnparsedObject       map[string]interface{} `json:"-"`
 	AdditionalProperties map[string]interface{} `json:"-"`
@@ -151,9 +155,9 @@ func (o *EngineDefinitionVersionQuery) UnsetRegex() {
 }
 
 // GetMin returns the Min field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *EngineDefinitionVersionQuery) GetMin() float {
+func (o *EngineDefinitionVersionQuery) GetMin() float64 {
 	if o == nil || o.Min.Get() == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return *o.Min.Get()
@@ -162,7 +166,7 @@ func (o *EngineDefinitionVersionQuery) GetMin() float {
 // GetMinOk returns a tuple with the Min field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned.
-func (o *EngineDefinitionVersionQuery) GetMinOk() (*float, bool) {
+func (o *EngineDefinitionVersionQuery) GetMinOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -174,8 +178,8 @@ func (o *EngineDefinitionVersionQuery) HasMin() bool {
 	return o != nil && o.Min.IsSet()
 }
 
-// SetMin gets a reference to the given common.NullableFloat and assigns it to the Min field.
-func (o *EngineDefinitionVersionQuery) SetMin(v float) {
+// SetMin gets a reference to the given common.NullableFloat64 and assigns it to the Min field.
+func (o *EngineDefinitionVersionQuery) SetMin(v float64) {
 	o.Min.Set(&v)
 }
 
@@ -190,9 +194,9 @@ func (o *EngineDefinitionVersionQuery) UnsetMin() {
 }
 
 // GetMax returns the Max field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *EngineDefinitionVersionQuery) GetMax() float {
+func (o *EngineDefinitionVersionQuery) GetMax() float64 {
 	if o == nil || o.Max.Get() == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return *o.Max.Get()
@@ -201,7 +205,7 @@ func (o *EngineDefinitionVersionQuery) GetMax() float {
 // GetMaxOk returns a tuple with the Max field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned.
-func (o *EngineDefinitionVersionQuery) GetMaxOk() (*float, bool) {
+func (o *EngineDefinitionVersionQuery) GetMaxOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -213,8 +217,8 @@ func (o *EngineDefinitionVersionQuery) HasMax() bool {
 	return o != nil && o.Max.IsSet()
 }
 
-// SetMax gets a reference to the given common.NullableFloat and assigns it to the Max field.
-func (o *EngineDefinitionVersionQuery) SetMax(v float) {
+// SetMax gets a reference to the given common.NullableFloat64 and assigns it to the Max field.
+func (o *EngineDefinitionVersionQuery) SetMax(v float64) {
 	o.Max.Set(&v)
 }
 
@@ -259,11 +263,11 @@ func (o EngineDefinitionVersionQuery) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *EngineDefinitionVersionQuery) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Sql    common.NullableString `json:"sql,omitempty"`
-		Column common.NullableString `json:"column,omitempty"`
-		Regex  common.NullableString `json:"regex,omitempty"`
-		Min    common.NullableFloat  `json:"min,omitempty"`
-		Max    common.NullableFloat  `json:"max,omitempty"`
+		Sql    common.NullableString  `json:"sql,omitempty"`
+		Column common.NullableString  `json:"column,omitempty"`
+		Regex  common.NullableString  `json:"regex,omitempty"`
+		Min    common.NullableFloat64 `json:"min,omitempty"`
+		Max    common.NullableFloat64 `json:"max,omitempty"`
 	}{}
 	if err = common.Unmarshal(bytes, &all); err != nil {
 		return err

--- a/api/kbcloud/admin/model_engine_list.go
+++ b/api/kbcloud/admin/model_engine_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type EngineList struct {
+	Items []Engine
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewEngineList instantiates a new EngineList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewEngineList() *EngineList {
+	this := EngineList{}
+	return &this
+}
+
+// NewEngineListWithDefaults instantiates a new EngineList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewEngineListWithDefaults() *EngineList {
+	this := EngineList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o EngineList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *EngineList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_engine_mapping.go
+++ b/api/kbcloud/admin/model_engine_mapping.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type EngineMapping struct {
 	Source              *string                    `json:"source,omitempty"`

--- a/api/kbcloud/admin/model_environment_module_list.go
+++ b/api/kbcloud/admin/model_environment_module_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type EnvironmentModuleList struct {
+	Items []EnvironmentModule
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewEnvironmentModuleList instantiates a new EnvironmentModuleList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewEnvironmentModuleList() *EnvironmentModuleList {
+	this := EnvironmentModuleList{}
+	return &this
+}
+
+// NewEnvironmentModuleListWithDefaults instantiates a new EnvironmentModuleList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewEnvironmentModuleListWithDefaults() *EnvironmentModuleList {
+	this := EnvironmentModuleList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o EnvironmentModuleList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *EnvironmentModuleList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_environment_pricing.go
+++ b/api/kbcloud/admin/model_environment_pricing.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // EnvironmentPricing the information of environment pricing
 type EnvironmentPricing struct {

--- a/api/kbcloud/admin/model_environment_update.go
+++ b/api/kbcloud/admin/model_environment_update.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // EnvironmentUpdate Environment info
 type EnvironmentUpdate struct {

--- a/api/kbcloud/admin/model_import_boolean_field.go
+++ b/api/kbcloud/admin/model_import_boolean_field.go
@@ -4,14 +4,16 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportBooleanField Configuration for a boolean-type field.
 type ImportBooleanField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -21,7 +23,7 @@ type ImportBooleanField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type    ImportFieldType     `json:"type,omitempty"`
+	Type    *ImportFieldType    `json:"type,omitempty"`
 	Default common.NullableBool `json:"default,omitempty"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
 	UnparsedObject       map[string]interface{} `json:"-"`
@@ -47,7 +49,7 @@ func (o *ImportBooleanField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -56,7 +58,7 @@ func (o *ImportBooleanField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -66,7 +68,7 @@ func (o *ImportBooleanField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportBooleanField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -75,7 +77,7 @@ func (o *ImportBooleanField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -84,7 +86,7 @@ func (o *ImportBooleanField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -94,7 +96,7 @@ func (o *ImportBooleanField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportBooleanField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -215,7 +217,7 @@ func (o *ImportBooleanField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -224,7 +226,7 @@ func (o *ImportBooleanField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -234,7 +236,7 @@ func (o *ImportBooleanField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportBooleanField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetDefault returns the Default field value if set, zero value otherwise.
@@ -315,13 +317,13 @@ func (o ImportBooleanField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportBooleanField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string              `json:"name,omitempty"`
-		Label       string              `json:"label,omitempty"`
+		Name        *string             `json:"name,omitempty"`
+		Label       *string             `json:"label,omitempty"`
 		Required    *bool               `json:"required,omitempty"`
 		Sensitive   *bool               `json:"sensitive,omitempty"`
 		Description *string             `json:"description,omitempty"`
 		Placeholder *string             `json:"placeholder,omitempty"`
-		Type        ImportFieldType     `json:"type,omitempty"`
+		Type        *ImportFieldType    `json:"type,omitempty"`
 		Default     common.NullableBool `json:"default,omitempty"`
 	}{}
 	if err = common.Unmarshal(bytes, &all); err != nil {

--- a/api/kbcloud/admin/model_import_connection_field.go
+++ b/api/kbcloud/admin/model_import_connection_field.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportConnectionField - Connection field configuration. Use `oneOf` to enforce strict type-specific properties.
 type ImportConnectionField struct {

--- a/api/kbcloud/admin/model_import_enum_field.go
+++ b/api/kbcloud/admin/model_import_enum_field.go
@@ -4,14 +4,16 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportEnumField Configuration for an enum-type field.
 type ImportEnumField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -21,7 +23,7 @@ type ImportEnumField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type ImportFieldType `json:"type,omitempty"`
+	Type *ImportFieldType `json:"type,omitempty"`
 	// List of available options for the enum.
 	Options []string              `json:"options,omitempty"`
 	Default common.NullableString `json:"default,omitempty"`
@@ -49,7 +51,7 @@ func (o *ImportEnumField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -58,7 +60,7 @@ func (o *ImportEnumField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -68,7 +70,7 @@ func (o *ImportEnumField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportEnumField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -77,7 +79,7 @@ func (o *ImportEnumField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -86,7 +88,7 @@ func (o *ImportEnumField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -96,7 +98,7 @@ func (o *ImportEnumField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportEnumField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -217,7 +219,7 @@ func (o *ImportEnumField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -226,7 +228,7 @@ func (o *ImportEnumField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -236,7 +238,7 @@ func (o *ImportEnumField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportEnumField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetOptions returns the Options field value if set, zero value otherwise.
@@ -348,13 +350,13 @@ func (o ImportEnumField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportEnumField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string                `json:"name,omitempty"`
-		Label       string                `json:"label,omitempty"`
+		Name        *string               `json:"name,omitempty"`
+		Label       *string               `json:"label,omitempty"`
 		Required    *bool                 `json:"required,omitempty"`
 		Sensitive   *bool                 `json:"sensitive,omitempty"`
 		Description *string               `json:"description,omitempty"`
 		Placeholder *string               `json:"placeholder,omitempty"`
-		Type        ImportFieldType       `json:"type,omitempty"`
+		Type        *ImportFieldType      `json:"type,omitempty"`
 		Options     []string              `json:"options,omitempty"`
 		Default     common.NullableString `json:"default,omitempty"`
 	}{}

--- a/api/kbcloud/admin/model_import_field_type.go
+++ b/api/kbcloud/admin/model_import_field_type.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import (
+	"fmt"
+
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+// ImportFieldType Import field type
+type ImportFieldType string
+
+// List of ImportFieldType.
+const (
+	ImportFieldTypeString  ImportFieldType = "string"
+	ImportFieldTypeInteger ImportFieldType = "integer"
+	ImportFieldTypeNumber  ImportFieldType = "number"
+	ImportFieldTypeBoolean ImportFieldType = "boolean"
+	ImportFieldTypeEnum    ImportFieldType = "enum"
+)
+
+var allowedImportFieldTypeEnumValues = []ImportFieldType{
+	ImportFieldTypeString,
+	ImportFieldTypeInteger,
+	ImportFieldTypeNumber,
+	ImportFieldTypeBoolean,
+	ImportFieldTypeEnum,
+}
+
+// GetAllowedValues returns the list of possible values.
+func (v *ImportFieldType) GetAllowedValues() []ImportFieldType {
+	return allowedImportFieldTypeEnumValues
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (v *ImportFieldType) UnmarshalJSON(src []byte) error {
+	var value string
+	err := common.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	*v = ImportFieldType(value)
+	return nil
+}
+
+// NewImportFieldTypeFromValue returns a pointer to a valid ImportFieldType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum.
+func NewImportFieldTypeFromValue(v string) (*ImportFieldType, error) {
+	ev := ImportFieldType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	}
+	return nil, fmt.Errorf("invalid value '%v' for ImportFieldType: valid values are %v", v, allowedImportFieldTypeEnumValues)
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise.
+func (v ImportFieldType) IsValid() bool {
+	for _, existing := range allowedImportFieldTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Ptr returns reference to ImportFieldType value.
+func (v ImportFieldType) Ptr() *ImportFieldType {
+	return &v
+}

--- a/api/kbcloud/admin/model_import_integer_field.go
+++ b/api/kbcloud/admin/model_import_integer_field.go
@@ -4,14 +4,16 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportIntegerField Configuration for an integer-type field.
 type ImportIntegerField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -21,7 +23,7 @@ type ImportIntegerField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type    ImportFieldType      `json:"type,omitempty"`
+	Type    *ImportFieldType     `json:"type,omitempty"`
 	Default common.NullableInt32 `json:"default,omitempty"`
 	// Validation rules for numeric field type
 	Validation *ImportNumericValidation `json:"validation,omitempty"`
@@ -49,7 +51,7 @@ func (o *ImportIntegerField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -58,7 +60,7 @@ func (o *ImportIntegerField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -68,7 +70,7 @@ func (o *ImportIntegerField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportIntegerField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -77,7 +79,7 @@ func (o *ImportIntegerField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -86,7 +88,7 @@ func (o *ImportIntegerField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -96,7 +98,7 @@ func (o *ImportIntegerField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportIntegerField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -217,7 +219,7 @@ func (o *ImportIntegerField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -226,7 +228,7 @@ func (o *ImportIntegerField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -236,7 +238,7 @@ func (o *ImportIntegerField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportIntegerField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetDefault returns the Default field value if set, zero value otherwise.
@@ -348,13 +350,13 @@ func (o ImportIntegerField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportIntegerField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string                   `json:"name,omitempty"`
-		Label       string                   `json:"label,omitempty"`
+		Name        *string                  `json:"name,omitempty"`
+		Label       *string                  `json:"label,omitempty"`
 		Required    *bool                    `json:"required,omitempty"`
 		Sensitive   *bool                    `json:"sensitive,omitempty"`
 		Description *string                  `json:"description,omitempty"`
 		Placeholder *string                  `json:"placeholder,omitempty"`
-		Type        ImportFieldType          `json:"type,omitempty"`
+		Type        *ImportFieldType         `json:"type,omitempty"`
 		Default     common.NullableInt32     `json:"default,omitempty"`
 		Validation  *ImportNumericValidation `json:"validation,omitempty"`
 	}{}
@@ -380,6 +382,9 @@ func (o *ImportIntegerField) UnmarshalJSON(bytes []byte) (err error) {
 		o.Type = all.Type
 	}
 	o.Default = all.Default
+	if all.Validation != nil && all.Validation.UnparsedObject != nil && o.UnparsedObject == nil {
+		hasInvalidField = true
+	}
 	o.Validation = all.Validation
 	if len(additionalProperties) > 0 {
 		o.AdditionalProperties = additionalProperties

--- a/api/kbcloud/admin/model_import_number_field.go
+++ b/api/kbcloud/admin/model_import_number_field.go
@@ -4,12 +4,16 @@
 
 package admin
 
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
 // ImportNumberField Configuration for a number-type field.
 type ImportNumberField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -19,8 +23,8 @@ type ImportNumberField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type    ImportFieldType      `json:"type,omitempty"`
-	Default common.NullableFloat `json:"default,omitempty"`
+	Type    *ImportFieldType       `json:"type,omitempty"`
+	Default common.NullableFloat64 `json:"default,omitempty"`
 	// Validation rules for numeric field type
 	Validation *ImportNumericValidation `json:"validation,omitempty"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
@@ -47,7 +51,7 @@ func (o *ImportNumberField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -56,7 +60,7 @@ func (o *ImportNumberField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -66,7 +70,7 @@ func (o *ImportNumberField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportNumberField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -75,7 +79,7 @@ func (o *ImportNumberField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -84,7 +88,7 @@ func (o *ImportNumberField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -94,7 +98,7 @@ func (o *ImportNumberField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportNumberField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -215,7 +219,7 @@ func (o *ImportNumberField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -224,7 +228,7 @@ func (o *ImportNumberField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -234,13 +238,13 @@ func (o *ImportNumberField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportNumberField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetDefault returns the Default field value if set, zero value otherwise.
-func (o *ImportNumberField) GetDefault() float {
+func (o *ImportNumberField) GetDefault() float64 {
 	if o == nil || o.Default.Get() == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return *o.Default.Get()
@@ -248,7 +252,7 @@ func (o *ImportNumberField) GetDefault() float {
 
 // GetDefaultOk returns a tuple with the Default field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ImportNumberField) GetDefaultOk() (*float, bool) {
+func (o *ImportNumberField) GetDefaultOk() (*float64, bool) {
 	if o == nil || o.Default.Get() == nil {
 		return nil, false
 	}
@@ -260,8 +264,8 @@ func (o *ImportNumberField) HasDefault() bool {
 	return o != nil && o.Default.IsSet()
 }
 
-// SetDefault gets a reference to the given common.NullableFloat and assigns it to the Default field.
-func (o *ImportNumberField) SetDefault(v float) {
+// SetDefault gets a reference to the given common.NullableFloat64 and assigns it to the Default field.
+func (o *ImportNumberField) SetDefault(v float64) {
 	o.Default.Set(&v)
 }
 
@@ -346,14 +350,14 @@ func (o ImportNumberField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportNumberField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string                   `json:"name,omitempty"`
-		Label       string                   `json:"label,omitempty"`
+		Name        *string                  `json:"name,omitempty"`
+		Label       *string                  `json:"label,omitempty"`
 		Required    *bool                    `json:"required,omitempty"`
 		Sensitive   *bool                    `json:"sensitive,omitempty"`
 		Description *string                  `json:"description,omitempty"`
 		Placeholder *string                  `json:"placeholder,omitempty"`
-		Type        ImportFieldType          `json:"type,omitempty"`
-		Default     common.NullableFloat     `json:"default,omitempty"`
+		Type        *ImportFieldType         `json:"type,omitempty"`
+		Default     common.NullableFloat64   `json:"default,omitempty"`
 		Validation  *ImportNumericValidation `json:"validation,omitempty"`
 	}{}
 	if err = common.Unmarshal(bytes, &all); err != nil {
@@ -378,6 +382,9 @@ func (o *ImportNumberField) UnmarshalJSON(bytes []byte) (err error) {
 		o.Type = all.Type
 	}
 	o.Default = all.Default
+	if all.Validation != nil && all.Validation.UnparsedObject != nil && o.UnparsedObject == nil {
+		hasInvalidField = true
+	}
 	o.Validation = all.Validation
 	if len(additionalProperties) > 0 {
 		o.AdditionalProperties = additionalProperties

--- a/api/kbcloud/admin/model_import_numeric_validation.go
+++ b/api/kbcloud/admin/model_import_numeric_validation.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// ImportNumericValidation Validation rules for numeric field type
+type ImportNumericValidation struct {
+	// Minimum value
+	Min *float64 `json:"min,omitempty"`
+	// Maximum value
+	Max *float64 `json:"max,omitempty"`
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewImportNumericValidation instantiates a new ImportNumericValidation object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewImportNumericValidation() *ImportNumericValidation {
+	this := ImportNumericValidation{}
+	return &this
+}
+
+// NewImportNumericValidationWithDefaults instantiates a new ImportNumericValidation object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewImportNumericValidationWithDefaults() *ImportNumericValidation {
+	this := ImportNumericValidation{}
+	return &this
+}
+
+// GetMin returns the Min field value if set, zero value otherwise.
+func (o *ImportNumericValidation) GetMin() float64 {
+	if o == nil || o.Min == nil {
+		var ret float64
+		return ret
+	}
+	return *o.Min
+}
+
+// GetMinOk returns a tuple with the Min field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportNumericValidation) GetMinOk() (*float64, bool) {
+	if o == nil || o.Min == nil {
+		return nil, false
+	}
+	return o.Min, true
+}
+
+// HasMin returns a boolean if a field has been set.
+func (o *ImportNumericValidation) HasMin() bool {
+	return o != nil && o.Min != nil
+}
+
+// SetMin gets a reference to the given float64 and assigns it to the Min field.
+func (o *ImportNumericValidation) SetMin(v float64) {
+	o.Min = &v
+}
+
+// GetMax returns the Max field value if set, zero value otherwise.
+func (o *ImportNumericValidation) GetMax() float64 {
+	if o == nil || o.Max == nil {
+		var ret float64
+		return ret
+	}
+	return *o.Max
+}
+
+// GetMaxOk returns a tuple with the Max field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportNumericValidation) GetMaxOk() (*float64, bool) {
+	if o == nil || o.Max == nil {
+		return nil, false
+	}
+	return o.Max, true
+}
+
+// HasMax returns a boolean if a field has been set.
+func (o *ImportNumericValidation) HasMax() bool {
+	return o != nil && o.Max != nil
+}
+
+// SetMax gets a reference to the given float64 and assigns it to the Max field.
+func (o *ImportNumericValidation) SetMax(v float64) {
+	o.Max = &v
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ImportNumericValidation) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	if o.Min != nil {
+		toSerialize["min"] = o.Min
+	}
+	if o.Max != nil {
+		toSerialize["max"] = o.Max
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ImportNumericValidation) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+		Min *float64 `json:"min,omitempty"`
+		Max *float64 `json:"max,omitempty"`
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{"min", "max"})
+	} else {
+		return err
+	}
+	o.Min = all.Min
+	o.Max = all.Max
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_import_option.go
+++ b/api/kbcloud/admin/model_import_option.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ImportOption struct {
 	// List of supported data sources for import

--- a/api/kbcloud/admin/model_import_string_field.go
+++ b/api/kbcloud/admin/model_import_string_field.go
@@ -4,14 +4,16 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportStringField Configuration for a string-type field.
 type ImportStringField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -21,7 +23,7 @@ type ImportStringField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type    ImportFieldType       `json:"type,omitempty"`
+	Type    *ImportFieldType      `json:"type,omitempty"`
 	Default common.NullableString `json:"default,omitempty"`
 	// Validation rules for string field type
 	Validation *ImportStringValidation `json:"validation,omitempty"`
@@ -49,7 +51,7 @@ func (o *ImportStringField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -58,7 +60,7 @@ func (o *ImportStringField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -68,7 +70,7 @@ func (o *ImportStringField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportStringField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -77,7 +79,7 @@ func (o *ImportStringField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -86,7 +88,7 @@ func (o *ImportStringField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -96,7 +98,7 @@ func (o *ImportStringField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportStringField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -217,7 +219,7 @@ func (o *ImportStringField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -226,7 +228,7 @@ func (o *ImportStringField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -236,7 +238,7 @@ func (o *ImportStringField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportStringField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetDefault returns the Default field value if set, zero value otherwise.
@@ -348,13 +350,13 @@ func (o ImportStringField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportStringField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string                  `json:"name,omitempty"`
-		Label       string                  `json:"label,omitempty"`
+		Name        *string                 `json:"name,omitempty"`
+		Label       *string                 `json:"label,omitempty"`
 		Required    *bool                   `json:"required,omitempty"`
 		Sensitive   *bool                   `json:"sensitive,omitempty"`
 		Description *string                 `json:"description,omitempty"`
 		Placeholder *string                 `json:"placeholder,omitempty"`
-		Type        ImportFieldType         `json:"type,omitempty"`
+		Type        *ImportFieldType        `json:"type,omitempty"`
 		Default     common.NullableString   `json:"default,omitempty"`
 		Validation  *ImportStringValidation `json:"validation,omitempty"`
 	}{}
@@ -380,6 +382,9 @@ func (o *ImportStringField) UnmarshalJSON(bytes []byte) (err error) {
 		o.Type = all.Type
 	}
 	o.Default = all.Default
+	if all.Validation != nil && all.Validation.UnparsedObject != nil && o.UnparsedObject == nil {
+		hasInvalidField = true
+	}
 	o.Validation = all.Validation
 	if len(additionalProperties) > 0 {
 		o.AdditionalProperties = additionalProperties

--- a/api/kbcloud/admin/model_import_string_validation.go
+++ b/api/kbcloud/admin/model_import_string_validation.go
@@ -1,0 +1,170 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// ImportStringValidation Validation rules for string field type
+type ImportStringValidation struct {
+	// Minimum length
+	MinLength *int32 `json:"minLength,omitempty"`
+	// Maximum length
+	MaxLength *int32 `json:"maxLength,omitempty"`
+	// Regex pattern
+	Pattern *string `json:"pattern,omitempty"`
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewImportStringValidation instantiates a new ImportStringValidation object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewImportStringValidation() *ImportStringValidation {
+	this := ImportStringValidation{}
+	return &this
+}
+
+// NewImportStringValidationWithDefaults instantiates a new ImportStringValidation object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewImportStringValidationWithDefaults() *ImportStringValidation {
+	this := ImportStringValidation{}
+	return &this
+}
+
+// GetMinLength returns the MinLength field value if set, zero value otherwise.
+func (o *ImportStringValidation) GetMinLength() int32 {
+	if o == nil || o.MinLength == nil {
+		var ret int32
+		return ret
+	}
+	return *o.MinLength
+}
+
+// GetMinLengthOk returns a tuple with the MinLength field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportStringValidation) GetMinLengthOk() (*int32, bool) {
+	if o == nil || o.MinLength == nil {
+		return nil, false
+	}
+	return o.MinLength, true
+}
+
+// HasMinLength returns a boolean if a field has been set.
+func (o *ImportStringValidation) HasMinLength() bool {
+	return o != nil && o.MinLength != nil
+}
+
+// SetMinLength gets a reference to the given int32 and assigns it to the MinLength field.
+func (o *ImportStringValidation) SetMinLength(v int32) {
+	o.MinLength = &v
+}
+
+// GetMaxLength returns the MaxLength field value if set, zero value otherwise.
+func (o *ImportStringValidation) GetMaxLength() int32 {
+	if o == nil || o.MaxLength == nil {
+		var ret int32
+		return ret
+	}
+	return *o.MaxLength
+}
+
+// GetMaxLengthOk returns a tuple with the MaxLength field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportStringValidation) GetMaxLengthOk() (*int32, bool) {
+	if o == nil || o.MaxLength == nil {
+		return nil, false
+	}
+	return o.MaxLength, true
+}
+
+// HasMaxLength returns a boolean if a field has been set.
+func (o *ImportStringValidation) HasMaxLength() bool {
+	return o != nil && o.MaxLength != nil
+}
+
+// SetMaxLength gets a reference to the given int32 and assigns it to the MaxLength field.
+func (o *ImportStringValidation) SetMaxLength(v int32) {
+	o.MaxLength = &v
+}
+
+// GetPattern returns the Pattern field value if set, zero value otherwise.
+func (o *ImportStringValidation) GetPattern() string {
+	if o == nil || o.Pattern == nil {
+		var ret string
+		return ret
+	}
+	return *o.Pattern
+}
+
+// GetPatternOk returns a tuple with the Pattern field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportStringValidation) GetPatternOk() (*string, bool) {
+	if o == nil || o.Pattern == nil {
+		return nil, false
+	}
+	return o.Pattern, true
+}
+
+// HasPattern returns a boolean if a field has been set.
+func (o *ImportStringValidation) HasPattern() bool {
+	return o != nil && o.Pattern != nil
+}
+
+// SetPattern gets a reference to the given string and assigns it to the Pattern field.
+func (o *ImportStringValidation) SetPattern(v string) {
+	o.Pattern = &v
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ImportStringValidation) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	if o.MinLength != nil {
+		toSerialize["minLength"] = o.MinLength
+	}
+	if o.MaxLength != nil {
+		toSerialize["maxLength"] = o.MaxLength
+	}
+	if o.Pattern != nil {
+		toSerialize["pattern"] = o.Pattern
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ImportStringValidation) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+		MinLength *int32  `json:"minLength,omitempty"`
+		MaxLength *int32  `json:"maxLength,omitempty"`
+		Pattern   *string `json:"pattern,omitempty"`
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{"minLength", "maxLength", "pattern"})
+	} else {
+		return err
+	}
+	o.MinLength = all.MinLength
+	o.MaxLength = all.MaxLength
+	o.Pattern = all.Pattern
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_init_options.go
+++ b/api/kbcloud/admin/model_init_options.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// InitOptions InitOptions is the list of init option
+type InitOptions struct {
+	Items []InitOptionItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewInitOptions instantiates a new InitOptions object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewInitOptions() *InitOptions {
+	this := InitOptions{}
+	return &this
+}
+
+// NewInitOptionsWithDefaults instantiates a new InitOptions object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewInitOptionsWithDefaults() *InitOptions {
+	this := InitOptions{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o InitOptions) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *InitOptions) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_io_quantity.go
+++ b/api/kbcloud/admin/model_io_quantity.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // IoQuantity IO Quantity describes IOPS and BPS of a volume
 type IoQuantity struct {

--- a/api/kbcloud/admin/model_json_body.go
+++ b/api/kbcloud/admin/model_json_body.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// JsonBody Represents a JSON body.
+type JsonBody struct {
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewJsonBody instantiates a new JsonBody object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewJsonBody() *JsonBody {
+	this := JsonBody{}
+	return &this
+}
+
+// NewJsonBodyWithDefaults instantiates a new JsonBody object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewJsonBodyWithDefaults() *JsonBody {
+	this := JsonBody{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o JsonBody) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *JsonBody) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{})
+	} else {
+		return err
+	}
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_kube_config.go
+++ b/api/kbcloud/admin/model_kube_config.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// KubeConfig The kubeconfig body as raw binary.
+type KubeConfig struct {
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewKubeConfig instantiates a new KubeConfig object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewKubeConfig() *KubeConfig {
+	this := KubeConfig{}
+	return &this
+}
+
+// NewKubeConfigWithDefaults instantiates a new KubeConfig object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewKubeConfigWithDefaults() *KubeConfig {
+	this := KubeConfig{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o KubeConfig) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *KubeConfig) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{})
+	} else {
+		return err
+	}
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_list_body.go
+++ b/api/kbcloud/admin/model_list_body.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// ListBody Represents a list of JSON bodies.
+type ListBody struct {
+	Items []map[string]interface{}
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewListBody instantiates a new ListBody object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewListBody() *ListBody {
+	this := ListBody{}
+	return &this
+}
+
+// NewListBodyWithDefaults instantiates a new ListBody object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewListBodyWithDefaults() *ListBody {
+	this := ListBody{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ListBody) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ListBody) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_metadata_object.go
+++ b/api/kbcloud/admin/model_metadata_object.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// MetadataObject Optional metadata for AI messages (e.g., tool calls, results)
+type MetadataObject struct {
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewMetadataObject instantiates a new MetadataObject object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewMetadataObject() *MetadataObject {
+	this := MetadataObject{}
+	return &this
+}
+
+// NewMetadataObjectWithDefaults instantiates a new MetadataObject object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewMetadataObjectWithDefaults() *MetadataObject {
+	this := MetadataObject{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o MetadataObject) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *MetadataObject) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{})
+	} else {
+		return err
+	}
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_module_definition.go
+++ b/api/kbcloud/admin/model_module_definition.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ModuleDefinition struct {
 	Name   *string                  `json:"name,omitempty"`

--- a/api/kbcloud/admin/model_module_definition_values.go
+++ b/api/kbcloud/admin/model_module_definition_values.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ModuleDefinitionValues struct {
 	ModuleValue *string                `json:"moduleValue,omitempty"`

--- a/api/kbcloud/admin/model_network_mode_option.go
+++ b/api/kbcloud/admin/model_network_mode_option.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type NetworkModeOption struct {
+	Items []NetworkModeOptionItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewNetworkModeOption instantiates a new NetworkModeOption object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewNetworkModeOption() *NetworkModeOption {
+	this := NetworkModeOption{}
+	return &this
+}
+
+// NewNetworkModeOptionWithDefaults instantiates a new NetworkModeOption object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewNetworkModeOptionWithDefaults() *NetworkModeOption {
+	this := NetworkModeOption{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o NetworkModeOption) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *NetworkModeOption) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_node_group_update.go
+++ b/api/kbcloud/admin/model_node_group_update.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // NodeGroupUpdate NodeGroup patch info
 type NodeGroupUpdate struct {

--- a/api/kbcloud/admin/model_node_pool.go
+++ b/api/kbcloud/admin/model_node_pool.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// NodePool Create your node plan, and the selected nodes will be used for pod scheduling
+type NodePool struct {
+	Items []NodePoolNode
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewNodePool instantiates a new NodePool object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewNodePool() *NodePool {
+	this := NodePool{}
+	return &this
+}
+
+// NewNodePoolWithDefaults instantiates a new NodePool object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewNodePoolWithDefaults() *NodePool {
+	this := NodePool{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o NodePool) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *NodePool) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_org_parameter_list.go
+++ b/api/kbcloud/admin/model_org_parameter_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// OrgParameterList org parameter list
+type OrgParameterList struct {
+	Items []OrgParameter
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewOrgParameterList instantiates a new OrgParameterList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewOrgParameterList() *OrgParameterList {
+	this := OrgParameterList{}
+	return &this
+}
+
+// NewOrgParameterListWithDefaults instantiates a new OrgParameterList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewOrgParameterListWithDefaults() *OrgParameterList {
+	this := OrgParameterList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o OrgParameterList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *OrgParameterList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_org_resource_quota.go
+++ b/api/kbcloud/admin/model_org_resource_quota.go
@@ -13,11 +13,11 @@ import (
 // OrgResourceQuota org resource quota
 type OrgResourceQuota struct {
 	// Maximum available vCPU. if set to 0, no limit
-	Cpu float `json:"cpu"`
+	Cpu float64 `json:"cpu"`
 	// Maximum available memory in GB. if set to 0, no limit
-	Memory float `json:"memory"`
+	Memory float64 `json:"memory"`
 	// Maximum available storage in GB. if set to 0, no limit
-	Storage float `json:"storage"`
+	Storage float64 `json:"storage"`
 	// Number of the clusters. key is engine type, values is the maximum number of engine
 	Clusters map[string]int32 `json:"clusters"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
@@ -29,7 +29,7 @@ type OrgResourceQuota struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed.
-func NewOrgResourceQuota(cpu float, memory float, storage float, clusters map[string]int32) *OrgResourceQuota {
+func NewOrgResourceQuota(cpu float64, memory float64, storage float64, clusters map[string]int32) *OrgResourceQuota {
 	this := OrgResourceQuota{}
 	this.Cpu = cpu
 	this.Memory = memory
@@ -47,9 +47,9 @@ func NewOrgResourceQuotaWithDefaults() *OrgResourceQuota {
 }
 
 // GetCpu returns the Cpu field value.
-func (o *OrgResourceQuota) GetCpu() float {
+func (o *OrgResourceQuota) GetCpu() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Cpu
@@ -57,7 +57,7 @@ func (o *OrgResourceQuota) GetCpu() float {
 
 // GetCpuOk returns a tuple with the Cpu field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuota) GetCpuOk() (*float, bool) {
+func (o *OrgResourceQuota) GetCpuOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -65,14 +65,14 @@ func (o *OrgResourceQuota) GetCpuOk() (*float, bool) {
 }
 
 // SetCpu sets field value.
-func (o *OrgResourceQuota) SetCpu(v float) {
+func (o *OrgResourceQuota) SetCpu(v float64) {
 	o.Cpu = v
 }
 
 // GetMemory returns the Memory field value.
-func (o *OrgResourceQuota) GetMemory() float {
+func (o *OrgResourceQuota) GetMemory() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Memory
@@ -80,7 +80,7 @@ func (o *OrgResourceQuota) GetMemory() float {
 
 // GetMemoryOk returns a tuple with the Memory field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuota) GetMemoryOk() (*float, bool) {
+func (o *OrgResourceQuota) GetMemoryOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -88,14 +88,14 @@ func (o *OrgResourceQuota) GetMemoryOk() (*float, bool) {
 }
 
 // SetMemory sets field value.
-func (o *OrgResourceQuota) SetMemory(v float) {
+func (o *OrgResourceQuota) SetMemory(v float64) {
 	o.Memory = v
 }
 
 // GetStorage returns the Storage field value.
-func (o *OrgResourceQuota) GetStorage() float {
+func (o *OrgResourceQuota) GetStorage() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Storage
@@ -103,7 +103,7 @@ func (o *OrgResourceQuota) GetStorage() float {
 
 // GetStorageOk returns a tuple with the Storage field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuota) GetStorageOk() (*float, bool) {
+func (o *OrgResourceQuota) GetStorageOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -111,7 +111,7 @@ func (o *OrgResourceQuota) GetStorageOk() (*float, bool) {
 }
 
 // SetStorage sets field value.
-func (o *OrgResourceQuota) SetStorage(v float) {
+func (o *OrgResourceQuota) SetStorage(v float64) {
 	o.Storage = v
 }
 
@@ -158,9 +158,9 @@ func (o OrgResourceQuota) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *OrgResourceQuota) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Cpu      *float            `json:"cpu"`
-		Memory   *float            `json:"memory"`
-		Storage  *float            `json:"storage"`
+		Cpu      *float64          `json:"cpu"`
+		Memory   *float64          `json:"memory"`
+		Storage  *float64          `json:"storage"`
 		Clusters *map[string]int32 `json:"clusters"`
 	}{}
 	if err = common.Unmarshal(bytes, &all); err != nil {

--- a/api/kbcloud/admin/model_org_resource_quota_and_usage.go
+++ b/api/kbcloud/admin/model_org_resource_quota_and_usage.go
@@ -13,11 +13,11 @@ import (
 // OrgResourceQuotaAndUsage org resource quota
 type OrgResourceQuotaAndUsage struct {
 	// Maximum available vCPU. if set to 0, no limit
-	Cpu float `json:"cpu"`
+	Cpu float64 `json:"cpu"`
 	// Maximum available memory in GB. if set to 0, no limit
-	Memory float `json:"memory"`
+	Memory float64 `json:"memory"`
 	// Maximum available storage in GB. if set to 0, no limit
-	Storage float `json:"storage"`
+	Storage float64 `json:"storage"`
 	// Number of the clusters. key is engine type, values is the maximum number of engine
 	Clusters map[string]int32 `json:"clusters"`
 	// org resource quota
@@ -31,7 +31,7 @@ type OrgResourceQuotaAndUsage struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed.
-func NewOrgResourceQuotaAndUsage(cpu float, memory float, storage float, clusters map[string]int32, usage OrgResourceQuota) *OrgResourceQuotaAndUsage {
+func NewOrgResourceQuotaAndUsage(cpu float64, memory float64, storage float64, clusters map[string]int32, usage OrgResourceQuota) *OrgResourceQuotaAndUsage {
 	this := OrgResourceQuotaAndUsage{}
 	this.Cpu = cpu
 	this.Memory = memory
@@ -50,9 +50,9 @@ func NewOrgResourceQuotaAndUsageWithDefaults() *OrgResourceQuotaAndUsage {
 }
 
 // GetCpu returns the Cpu field value.
-func (o *OrgResourceQuotaAndUsage) GetCpu() float {
+func (o *OrgResourceQuotaAndUsage) GetCpu() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Cpu
@@ -60,7 +60,7 @@ func (o *OrgResourceQuotaAndUsage) GetCpu() float {
 
 // GetCpuOk returns a tuple with the Cpu field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuotaAndUsage) GetCpuOk() (*float, bool) {
+func (o *OrgResourceQuotaAndUsage) GetCpuOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -68,14 +68,14 @@ func (o *OrgResourceQuotaAndUsage) GetCpuOk() (*float, bool) {
 }
 
 // SetCpu sets field value.
-func (o *OrgResourceQuotaAndUsage) SetCpu(v float) {
+func (o *OrgResourceQuotaAndUsage) SetCpu(v float64) {
 	o.Cpu = v
 }
 
 // GetMemory returns the Memory field value.
-func (o *OrgResourceQuotaAndUsage) GetMemory() float {
+func (o *OrgResourceQuotaAndUsage) GetMemory() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Memory
@@ -83,7 +83,7 @@ func (o *OrgResourceQuotaAndUsage) GetMemory() float {
 
 // GetMemoryOk returns a tuple with the Memory field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuotaAndUsage) GetMemoryOk() (*float, bool) {
+func (o *OrgResourceQuotaAndUsage) GetMemoryOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -91,14 +91,14 @@ func (o *OrgResourceQuotaAndUsage) GetMemoryOk() (*float, bool) {
 }
 
 // SetMemory sets field value.
-func (o *OrgResourceQuotaAndUsage) SetMemory(v float) {
+func (o *OrgResourceQuotaAndUsage) SetMemory(v float64) {
 	o.Memory = v
 }
 
 // GetStorage returns the Storage field value.
-func (o *OrgResourceQuotaAndUsage) GetStorage() float {
+func (o *OrgResourceQuotaAndUsage) GetStorage() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Storage
@@ -106,7 +106,7 @@ func (o *OrgResourceQuotaAndUsage) GetStorage() float {
 
 // GetStorageOk returns a tuple with the Storage field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuotaAndUsage) GetStorageOk() (*float, bool) {
+func (o *OrgResourceQuotaAndUsage) GetStorageOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -114,7 +114,7 @@ func (o *OrgResourceQuotaAndUsage) GetStorageOk() (*float, bool) {
 }
 
 // SetStorage sets field value.
-func (o *OrgResourceQuotaAndUsage) SetStorage(v float) {
+func (o *OrgResourceQuotaAndUsage) SetStorage(v float64) {
 	o.Storage = v
 }
 
@@ -185,9 +185,9 @@ func (o OrgResourceQuotaAndUsage) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *OrgResourceQuotaAndUsage) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Cpu      *float            `json:"cpu"`
-		Memory   *float            `json:"memory"`
-		Storage  *float            `json:"storage"`
+		Cpu      *float64          `json:"cpu"`
+		Memory   *float64          `json:"memory"`
+		Storage  *float64          `json:"storage"`
 		Clusters *map[string]int32 `json:"clusters"`
 		Usage    *OrgResourceQuota `json:"usage"`
 	}{}

--- a/api/kbcloud/admin/model_param_tpls.go
+++ b/api/kbcloud/admin/model_param_tpls.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// ParamTpls Items is the list of parameter template in the list
+type ParamTpls struct {
+	Items []ParamTplsItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewParamTpls instantiates a new ParamTpls object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewParamTpls() *ParamTpls {
+	this := ParamTpls{}
+	return &this
+}
+
+// NewParamTplsWithDefaults instantiates a new ParamTpls object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewParamTplsWithDefaults() *ParamTpls {
+	this := ParamTpls{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ParamTpls) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ParamTpls) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_partition_list.go
+++ b/api/kbcloud/admin/model_partition_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type PartitionList struct {
+	Items []Partition
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewPartitionList instantiates a new PartitionList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewPartitionList() *PartitionList {
+	this := PartitionList{}
+	return &this
+}
+
+// NewPartitionListWithDefaults instantiates a new PartitionList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewPartitionListWithDefaults() *PartitionList {
+	this := PartitionList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o PartitionList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *PartitionList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_persistent_volume_claim_list.go
+++ b/api/kbcloud/admin/model_persistent_volume_claim_list.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // PersistentVolumeClaimList the List stands for stats for persistentvolumeclaims.
 type PersistentVolumeClaimList struct {

--- a/api/kbcloud/admin/model_phone_number.go
+++ b/api/kbcloud/admin/model_phone_number.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// PhoneNumber The phonenumber for the user.
+type PhoneNumber struct {
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewPhoneNumber instantiates a new PhoneNumber object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewPhoneNumber() *PhoneNumber {
+	this := PhoneNumber{}
+	return &this
+}
+
+// NewPhoneNumberWithDefaults instantiates a new PhoneNumber object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewPhoneNumberWithDefaults() *PhoneNumber {
+	this := PhoneNumber{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o PhoneNumber) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *PhoneNumber) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{})
+	} else {
+		return err
+	}
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_privilege_list.go
+++ b/api/kbcloud/admin/model_privilege_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// PrivilegeList A list of privileges and their databases.
+type PrivilegeList struct {
+	Items []PrivilegeListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewPrivilegeList instantiates a new PrivilegeList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewPrivilegeList() *PrivilegeList {
+	this := PrivilegeList{}
+	return &this
+}
+
+// NewPrivilegeListWithDefaults instantiates a new PrivilegeList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewPrivilegeListWithDefaults() *PrivilegeList {
+	this := PrivilegeList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o PrivilegeList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *PrivilegeList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_related_cluster_list.go
+++ b/api/kbcloud/admin/model_related_cluster_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type RelatedClusterList struct {
+	Items []RelatedClusterListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewRelatedClusterList instantiates a new RelatedClusterList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewRelatedClusterList() *RelatedClusterList {
+	this := RelatedClusterList{}
+	return &this
+}
+
+// NewRelatedClusterListWithDefaults instantiates a new RelatedClusterList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewRelatedClusterListWithDefaults() *RelatedClusterList {
+	this := RelatedClusterList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o RelatedClusterList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *RelatedClusterList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_replication_metadata_object.go
+++ b/api/kbcloud/admin/model_replication_metadata_object.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ReplicationMetadataObject struct {
 	MetadataType *string                     `json:"metadataType,omitempty"`

--- a/api/kbcloud/admin/model_show_data_request.go
+++ b/api/kbcloud/admin/model_show_data_request.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ShowDataRequest struct {
 	// the database of the table or view

--- a/api/kbcloud/admin/model_standard_definition.go
+++ b/api/kbcloud/admin/model_standard_definition.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type StandardDefinition struct {
 	Name        *string             `json:"name,omitempty"`

--- a/api/kbcloud/admin/model_standard_resource.go
+++ b/api/kbcloud/admin/model_standard_resource.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type StandardResource struct {
 	Limit   common.NullableFloat64 `json:"limit,omitempty"`

--- a/api/kbcloud/admin/model_storage_class_list.go
+++ b/api/kbcloud/admin/model_storage_class_list.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // StorageClassList StorageClassList stands for stats for storage classes.
 type StorageClassList struct {

--- a/api/kbcloud/admin/model_storage_list.go
+++ b/api/kbcloud/admin/model_storage_list.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type StorageList struct {
+	Items []Storage
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewStorageList instantiates a new StorageList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewStorageList() *StorageList {
+	this := StorageList{}
+	return &this
+}
+
+// NewStorageListWithDefaults instantiates a new StorageList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewStorageListWithDefaults() *StorageList {
+	this := StorageList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o StorageList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *StorageList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_storage_provider_list.go
+++ b/api/kbcloud/admin/model_storage_provider_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type StorageProviderList struct {
+	Items []StorageProvider
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewStorageProviderList instantiates a new StorageProviderList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewStorageProviderList() *StorageProviderList {
+	this := StorageProviderList{}
+	return &this
+}
+
+// NewStorageProviderListWithDefaults instantiates a new StorageProviderList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewStorageProviderListWithDefaults() *StorageProviderList {
+	this := StorageProviderList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o StorageProviderList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *StorageProviderList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_storage_provisioner.go
+++ b/api/kbcloud/admin/model_storage_provisioner.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // StorageProvisioner StorageProvisioner provides detailed information about the provisioner used by storage classes.
 type StorageProvisioner struct {

--- a/api/kbcloud/admin/model_string_list.go
+++ b/api/kbcloud/admin/model_string_list.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// StringList Represents a list of strings.
+type StringList struct {
+	Items []string
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewStringList instantiates a new StringList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewStringList() *StringList {
+	this := StringList{}
+	return &this
+}
+
+// NewStringListWithDefaults instantiates a new StringList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewStringListWithDefaults() *StringList {
+	this := StringList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o StringList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *StringList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_tenant_list.go
+++ b/api/kbcloud/admin/model_tenant_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// TenantList result set of Tenant
+type TenantList struct {
+	Items []Tenant
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTenantList instantiates a new TenantList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTenantList() *TenantList {
+	this := TenantList{}
+	return &this
+}
+
+// NewTenantListWithDefaults instantiates a new TenantList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTenantListWithDefaults() *TenantList {
+	this := TenantList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TenantList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TenantList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_tls_cert_list.go
+++ b/api/kbcloud/admin/model_tls_cert_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type TlsCertList struct {
+	Items []TlsCert
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTlsCertList instantiates a new TlsCertList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTlsCertList() *TlsCertList {
+	this := TlsCertList{}
+	return &this
+}
+
+// NewTlsCertListWithDefaults instantiates a new TlsCertList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTlsCertListWithDefaults() *TlsCertList {
+	this := TlsCertList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TlsCertList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TlsCertList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_topic_broker_list.go
+++ b/api/kbcloud/admin/model_topic_broker_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type TopicBrokerList struct {
+	Items []Broker
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTopicBrokerList instantiates a new TopicBrokerList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTopicBrokerList() *TopicBrokerList {
+	this := TopicBrokerList{}
+	return &this
+}
+
+// NewTopicBrokerListWithDefaults instantiates a new TopicBrokerList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTopicBrokerListWithDefaults() *TopicBrokerList {
+	this := TopicBrokerList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TopicBrokerList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TopicBrokerList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_topic_message_list.go
+++ b/api/kbcloud/admin/model_topic_message_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type TopicMessageList struct {
+	Items []TopicMessage
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTopicMessageList instantiates a new TopicMessageList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTopicMessageList() *TopicMessageList {
+	this := TopicMessageList{}
+	return &this
+}
+
+// NewTopicMessageListWithDefaults instantiates a new TopicMessageList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTopicMessageListWithDefaults() *TopicMessageList {
+	this := TopicMessageList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TopicMessageList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TopicMessageList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_topic_offset.go
+++ b/api/kbcloud/admin/model_topic_offset.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type TopicOffset struct {
 	// 主题名称

--- a/api/kbcloud/admin/model_topic_offset_list.go
+++ b/api/kbcloud/admin/model_topic_offset_list.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type TopicOffsetList struct {
+	Items []TopicOffset
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTopicOffsetList instantiates a new TopicOffsetList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTopicOffsetList() *TopicOffsetList {
+	this := TopicOffsetList{}
+	return &this
+}
+
+// NewTopicOffsetListWithDefaults instantiates a new TopicOffsetList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTopicOffsetListWithDefaults() *TopicOffsetList {
+	this := TopicOffsetList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TopicOffsetList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TopicOffsetList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_topics_list.go
+++ b/api/kbcloud/admin/model_topics_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package admin
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type TopicsList struct {
+	Items []Topic
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTopicsList instantiates a new TopicsList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTopicsList() *TopicsList {
+	this := TopicsList{}
+	return &this
+}
+
+// NewTopicsListWithDefaults instantiates a new TopicsList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTopicsListWithDefaults() *TopicsList {
+	this := TopicsList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TopicsList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TopicsList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/admin/model_workflow_list.go
+++ b/api/kbcloud/admin/model_workflow_list.go
@@ -4,7 +4,9 @@
 
 package admin
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // WorkflowList component management workflow list
 type WorkflowList struct {

--- a/api/kbcloud/model_account_list.go
+++ b/api/kbcloud/model_account_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type AccountList struct {
+	Items []AccountListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewAccountList instantiates a new AccountList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewAccountList() *AccountList {
+	this := AccountList{}
+	return &this
+}
+
+// NewAccountListWithDefaults instantiates a new AccountList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewAccountListWithDefaults() *AccountList {
+	this := AccountList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o AccountList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *AccountList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_autohealing_list.go
+++ b/api/kbcloud/model_autohealing_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// AutohealingList An Autohealing object in k8s
+type AutohealingList struct {
+	Items []AutohealingListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewAutohealingList instantiates a new AutohealingList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewAutohealingList() *AutohealingList {
+	this := AutohealingList{}
+	return &this
+}
+
+// NewAutohealingListWithDefaults instantiates a new AutohealingList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewAutohealingListWithDefaults() *AutohealingList {
+	this := AutohealingList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o AutohealingList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *AutohealingList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_available_cluster_list.go
+++ b/api/kbcloud/model_available_cluster_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type AvailableClusterList struct {
+	Items []AvailableClusterListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewAvailableClusterList instantiates a new AvailableClusterList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewAvailableClusterList() *AvailableClusterList {
+	this := AvailableClusterList{}
+	return &this
+}
+
+// NewAvailableClusterListWithDefaults instantiates a new AvailableClusterList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewAvailableClusterListWithDefaults() *AvailableClusterList {
+	this := AvailableClusterList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o AvailableClusterList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *AvailableClusterList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_benchmark_list.go
+++ b/api/kbcloud/model_benchmark_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// BenchmarkList BenchmarkList is a list of benchmarks
+type BenchmarkList struct {
+	Items []Benchmark
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewBenchmarkList instantiates a new BenchmarkList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewBenchmarkList() *BenchmarkList {
+	this := BenchmarkList{}
+	return &this
+}
+
+// NewBenchmarkListWithDefaults instantiates a new BenchmarkList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewBenchmarkListWithDefaults() *BenchmarkList {
+	this := BenchmarkList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o BenchmarkList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *BenchmarkList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_bill.go
+++ b/api/kbcloud/model_bill.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // Bill Task information
 type Bill struct {

--- a/api/kbcloud/model_broker_list.go
+++ b/api/kbcloud/model_broker_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type BrokerList struct {
+	Items []Broker
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewBrokerList instantiates a new BrokerList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewBrokerList() *BrokerList {
+	this := BrokerList{}
+	return &this
+}
+
+// NewBrokerListWithDefaults instantiates a new BrokerList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewBrokerListWithDefaults() *BrokerList {
+	this := BrokerList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o BrokerList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *BrokerList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_cdc_cluster_endpoint.go
+++ b/api/kbcloud/model_cdc_cluster_endpoint.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcClusterEndpoint struct {
 	Role         *string               `json:"role,omitempty"`

--- a/api/kbcloud/model_cdc_lifecycle.go
+++ b/api/kbcloud/model_cdc_lifecycle.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcLifecycle struct {
 	PreStart  *CdcLifecycleAction `json:"preStart,omitempty"`

--- a/api/kbcloud/model_cdc_lifecycle_action.go
+++ b/api/kbcloud/model_cdc_lifecycle_action.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcLifecycleAction struct {
 	Name        *string         `json:"name,omitempty"`

--- a/api/kbcloud/model_cdc_option.go
+++ b/api/kbcloud/model_cdc_option.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcOption struct {
 	Versions []string           `json:"versions,omitempty"`

--- a/api/kbcloud/model_cdc_settings.go
+++ b/api/kbcloud/model_cdc_settings.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcSettings struct {
 	Config    *CdcClusterConfig   `json:"config,omitempty"`

--- a/api/kbcloud/model_cdc_sql_executor.go
+++ b/api/kbcloud/model_cdc_sql_executor.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcSqlExecutor struct {
 	Sql          []string              `json:"sql,omitempty"`

--- a/api/kbcloud/model_cdc_tool_template.go
+++ b/api/kbcloud/model_cdc_tool_template.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcToolTemplate struct {
 	Image              *string                `json:"image,omitempty"`

--- a/api/kbcloud/model_cdc_worker_template.go
+++ b/api/kbcloud/model_cdc_worker_template.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type CdcWorkerTemplate struct {
 	UsingTool *CdcToolTemplate `json:"usingTool,omitempty"`

--- a/api/kbcloud/model_cluster_backup.go
+++ b/api/kbcloud/model_cluster_backup.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterBackup clusterBackup is the payload for cluster backup
 type ClusterBackup struct {

--- a/api/kbcloud/model_cluster_metrics.go
+++ b/api/kbcloud/model_cluster_metrics.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterMetrics Cluster metrics
 type ClusterMetrics struct {

--- a/api/kbcloud/model_cluster_task_list.go
+++ b/api/kbcloud/model_cluster_task_list.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterTaskList TaskList is a list of operation task objects
 type ClusterTaskList struct {

--- a/api/kbcloud/model_cluster_task_progresses.go
+++ b/api/kbcloud/model_cluster_task_progresses.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterTaskProgresses clusterTaskProgresses is a list of task progress detail
 type ClusterTaskProgresses struct {

--- a/api/kbcloud/model_cluster_update.go
+++ b/api/kbcloud/model_cluster_update.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ClusterUpdate ClusterUpdate is the payload to update a KubeBlocks cluster
 type ClusterUpdate struct {

--- a/api/kbcloud/model_component_item.go
+++ b/api/kbcloud/model_component_item.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ComponentItem ComponentItem is the information of a component
 type ComponentItem struct {

--- a/api/kbcloud/model_component_volume_item.go
+++ b/api/kbcloud/model_component_volume_item.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ComponentVolumeItem ComponentVolumeItem is the information of a component volume
 type ComponentVolumeItem struct {

--- a/api/kbcloud/model_components.go
+++ b/api/kbcloud/model_components.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+// Components Components is the list of components
+type Components struct {
+	Items []ComponentItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewComponents instantiates a new Components object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewComponents() *Components {
+	this := Components{}
+	return &this
+}
+
+// NewComponentsWithDefaults instantiates a new Components object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewComponentsWithDefaults() *Components {
+	this := Components{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o Components) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *Components) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_components_create.go
+++ b/api/kbcloud/model_components_create.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+// ComponentsCreate Components is the list of components
+type ComponentsCreate struct {
+	Items []ComponentItemCreate
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewComponentsCreate instantiates a new ComponentsCreate object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewComponentsCreate() *ComponentsCreate {
+	this := ComponentsCreate{}
+	return &this
+}
+
+// NewComponentsCreateWithDefaults instantiates a new ComponentsCreate object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewComponentsCreateWithDefaults() *ComponentsCreate {
+	this := ComponentsCreate{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ComponentsCreate) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ComponentsCreate) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_config_list.go
+++ b/api/kbcloud/model_config_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type ConfigList struct {
+	Items []ConfigEntry
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewConfigList instantiates a new ConfigList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewConfigList() *ConfigList {
+	this := ConfigList{}
+	return &this
+}
+
+// NewConfigListWithDefaults instantiates a new ConfigList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewConfigListWithDefaults() *ConfigList {
+	this := ConfigList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ConfigList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ConfigList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_consumer_group_describe_response.go
+++ b/api/kbcloud/model_consumer_group_describe_response.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type ConsumerGroupDescribeResponse struct {
+	Items []ConsumerGroupDescribe
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewConsumerGroupDescribeResponse instantiates a new ConsumerGroupDescribeResponse object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewConsumerGroupDescribeResponse() *ConsumerGroupDescribeResponse {
+	this := ConsumerGroupDescribeResponse{}
+	return &this
+}
+
+// NewConsumerGroupDescribeResponseWithDefaults instantiates a new ConsumerGroupDescribeResponse object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewConsumerGroupDescribeResponseWithDefaults() *ConsumerGroupDescribeResponse {
+	this := ConsumerGroupDescribeResponse{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ConsumerGroupDescribeResponse) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ConsumerGroupDescribeResponse) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_consumer_group_list.go
+++ b/api/kbcloud/model_consumer_group_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type ConsumerGroupList struct {
+	Items []ConsumerGroup
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewConsumerGroupList instantiates a new ConsumerGroupList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewConsumerGroupList() *ConsumerGroupList {
+	this := ConsumerGroupList{}
+	return &this
+}
+
+// NewConsumerGroupListWithDefaults instantiates a new ConsumerGroupList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewConsumerGroupListWithDefaults() *ConsumerGroupList {
+	this := ConsumerGroupList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ConsumerGroupList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ConsumerGroupList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_data_channel_detail.go
+++ b/api/kbcloud/model_data_channel_detail.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DataChannelDetail struct {
 	Channel  *DataChannelItem     `json:"channel,omitempty"`

--- a/api/kbcloud/model_data_channel_endpoint_create.go
+++ b/api/kbcloud/model_data_channel_endpoint_create.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DataChannelEndpointCreate struct {
 	EngineName     *string                       `json:"engineName,omitempty"`

--- a/api/kbcloud/model_data_channel_list.go
+++ b/api/kbcloud/model_data_channel_list.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type DataChannelList struct {
+	Items []DataChannelItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDataChannelList instantiates a new DataChannelList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDataChannelList() *DataChannelList {
+	this := DataChannelList{}
+	return &this
+}
+
+// NewDataChannelListWithDefaults instantiates a new DataChannelList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDataChannelListWithDefaults() *DataChannelList {
+	this := DataChannelList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DataChannelList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DataChannelList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_data_channel_module_progress.go
+++ b/api/kbcloud/model_data_channel_module_progress.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DataChannelModuleProgress struct {
 	ModuleName *string                `json:"moduleName,omitempty"`

--- a/api/kbcloud/model_data_channel_object.go
+++ b/api/kbcloud/model_data_channel_object.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DataChannelObject struct {
 	IncludeObjects []string                    `json:"includeObjects,omitempty"`

--- a/api/kbcloud/model_data_channel_progress.go
+++ b/api/kbcloud/model_data_channel_progress.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DataChannelProgress struct {
 	Progress       common.NullableFloat64      `json:"progress,omitempty"`

--- a/api/kbcloud/model_data_replication_create.go
+++ b/api/kbcloud/model_data_replication_create.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DataReplicationCreate struct {
 	ChannelName        *string                    `json:"channelName,omitempty"`

--- a/api/kbcloud/model_data_replication_event_list.go
+++ b/api/kbcloud/model_data_replication_event_list.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type DataReplication_eventList struct {
+	Items []EventItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDataReplication_eventList instantiates a new DataReplication_eventList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDataReplication_eventList() *DataReplication_eventList {
+	this := DataReplication_eventList{}
+	return &this
+}
+
+// NewDataReplication_eventListWithDefaults instantiates a new DataReplication_eventList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDataReplication_eventListWithDefaults() *DataReplication_eventList {
+	this := DataReplication_eventList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DataReplication_eventList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DataReplication_eventList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_data_replication_option.go
+++ b/api/kbcloud/model_data_replication_option.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DataReplicationOption struct {
 	ModuleDefinitions []ModuleDefinition   `json:"moduleDefinitions,omitempty"`

--- a/api/kbcloud/model_datasource_list.go
+++ b/api/kbcloud/model_datasource_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DatasourceList struct {
+	Items []Datasource
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDatasourceList instantiates a new DatasourceList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDatasourceList() *DatasourceList {
+	this := DatasourceList{}
+	return &this
+}
+
+// NewDatasourceListWithDefaults instantiates a new DatasourceList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDatasourceListWithDefaults() *DatasourceList {
+	this := DatasourceList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DatasourceList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DatasourceList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_disaster_recovery_cluster_item.go
+++ b/api/kbcloud/model_disaster_recovery_cluster_item.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // DisasterRecoveryClusterItem DisasterRecovery cluster information
 type DisasterRecoveryClusterItem struct {

--- a/api/kbcloud/model_dm_tablespace_list.go
+++ b/api/kbcloud/model_dm_tablespace_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// DmTablespaceList the list of tablespace
+type DmTablespaceList struct {
+	Items []DmTablespace
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmTablespaceList instantiates a new DmTablespaceList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmTablespaceList() *DmTablespaceList {
+	this := DmTablespaceList{}
+	return &this
+}
+
+// NewDmTablespaceListWithDefaults instantiates a new DmTablespaceList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmTablespaceListWithDefaults() *DmTablespaceList {
+	this := DmTablespaceList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmTablespaceList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmTablespaceList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_dms_exclude_constraint.go
+++ b/api/kbcloud/model_dms_exclude_constraint.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsExcludeConstraint struct {
 	// The name of the exclude constraint

--- a/api/kbcloud/model_dms_foreign_key.go
+++ b/api/kbcloud/model_dms_foreign_key.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsForeignKey struct {
 	// The name of the foreign key

--- a/api/kbcloud/model_dms_foreign_key_reference.go
+++ b/api/kbcloud/model_dms_foreign_key_reference.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // DmsForeignKeyReference The reference details of the foreign key
 type DmsForeignKeyReference struct {

--- a/api/kbcloud/model_dms_object_list.go
+++ b/api/kbcloud/model_dms_object_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsObjectList struct {
+	Items []DmsObject
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsObjectList instantiates a new DmsObjectList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsObjectList() *DmsObjectList {
+	this := DmsObjectList{}
+	return &this
+}
+
+// NewDmsObjectListWithDefaults instantiates a new DmsObjectList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsObjectListWithDefaults() *DmsObjectList {
+	this := DmsObjectList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsObjectList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsObjectList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_dms_object_name_list.go
+++ b/api/kbcloud/model_dms_object_name_list.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsObjectNameList struct {
+	Items []string
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsObjectNameList instantiates a new DmsObjectNameList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsObjectNameList() *DmsObjectNameList {
+	this := DmsObjectNameList{}
+	return &this
+}
+
+// NewDmsObjectNameListWithDefaults instantiates a new DmsObjectNameList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsObjectNameListWithDefaults() *DmsObjectNameList {
+	this := DmsObjectNameList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsObjectNameList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsObjectNameList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_dms_parameter_list.go
+++ b/api/kbcloud/model_dms_parameter_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsParameterList struct {
+	Items []DmsObParameter
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsParameterList instantiates a new DmsParameterList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsParameterList() *DmsParameterList {
+	this := DmsParameterList{}
+	return &this
+}
+
+// NewDmsParameterListWithDefaults instantiates a new DmsParameterList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsParameterListWithDefaults() *DmsParameterList {
+	this := DmsParameterList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsParameterList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsParameterList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_dms_primary_key.go
+++ b/api/kbcloud/model_dms_primary_key.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsPrimaryKey struct {
 	// The name of the primary key

--- a/api/kbcloud/model_dms_query_history_list.go
+++ b/api/kbcloud/model_dms_query_history_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsQueryHistoryList struct {
+	Items []DmsQueryHistory
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsQueryHistoryList instantiates a new DmsQueryHistoryList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsQueryHistoryList() *DmsQueryHistoryList {
+	this := DmsQueryHistoryList{}
+	return &this
+}
+
+// NewDmsQueryHistoryListWithDefaults instantiates a new DmsQueryHistoryList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsQueryHistoryListWithDefaults() *DmsQueryHistoryList {
+	this := DmsQueryHistoryList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsQueryHistoryList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsQueryHistoryList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_dms_query_request.go
+++ b/api/kbcloud/model_dms_query_request.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsQueryRequest struct {
 	// the database of the table or view

--- a/api/kbcloud/model_dms_query_response.go
+++ b/api/kbcloud/model_dms_query_response.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsQueryResponse struct {
 	// result set of query

--- a/api/kbcloud/model_dms_row.go
+++ b/api/kbcloud/model_dms_row.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsRow struct {
+	Items []interface{}
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsRow instantiates a new DmsRow object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsRow() *DmsRow {
+	this := DmsRow{}
+	return &this
+}
+
+// NewDmsRowWithDefaults instantiates a new DmsRow object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsRowWithDefaults() *DmsRow {
+	this := DmsRow{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsRow) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsRow) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_dms_schema_list.go
+++ b/api/kbcloud/model_dms_schema_list.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type DmsSchemaList struct {
+	Items []string
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsSchemaList instantiates a new DmsSchemaList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsSchemaList() *DmsSchemaList {
+	this := DmsSchemaList{}
+	return &this
+}
+
+// NewDmsSchemaListWithDefaults instantiates a new DmsSchemaList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsSchemaListWithDefaults() *DmsSchemaList {
+	this := DmsSchemaList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsSchemaList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsSchemaList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_dms_session_list.go
+++ b/api/kbcloud/model_dms_session_list.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type DmsSessionList struct {
+	Items []DmsSession
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewDmsSessionList instantiates a new DmsSessionList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewDmsSessionList() *DmsSessionList {
+	this := DmsSessionList{}
+	return &this
+}
+
+// NewDmsSessionListWithDefaults instantiates a new DmsSessionList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewDmsSessionListWithDefaults() *DmsSessionList {
+	this := DmsSessionList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o DmsSessionList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *DmsSessionList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_dms_table_column.go
+++ b/api/kbcloud/model_dms_table_column.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTableColumn struct {
 	// The name of the column

--- a/api/kbcloud/model_dms_table_column_generated.go
+++ b/api/kbcloud/model_dms_table_column_generated.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // DmsTableColumnGenerated Generated column information
 type DmsTableColumnGenerated struct {

--- a/api/kbcloud/model_dms_table_index.go
+++ b/api/kbcloud/model_dms_table_index.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTableIndex struct {
 	// The name of the index

--- a/api/kbcloud/model_dms_table_metadata.go
+++ b/api/kbcloud/model_dms_table_metadata.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTableMetadata struct {
 	// The name of the table

--- a/api/kbcloud/model_dms_table_options.go
+++ b/api/kbcloud/model_dms_table_options.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTableOptions struct {
 	// The storage engine for the table

--- a/api/kbcloud/model_dms_task_list.go
+++ b/api/kbcloud/model_dms_task_list.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsTaskList struct {
 	Tasks []DmsTaskInfo `json:"tasks,omitempty"`

--- a/api/kbcloud/model_dms_unique_key.go
+++ b/api/kbcloud/model_dms_unique_key.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsUniqueKey struct {
 	// The name of the unique key

--- a/api/kbcloud/model_dms_view_metadata.go
+++ b/api/kbcloud/model_dms_view_metadata.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type DmsViewMetadata struct {
 	// The name of the view

--- a/api/kbcloud/model_engine_definition.go
+++ b/api/kbcloud/model_engine_definition.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type EngineDefinition struct {
 	Name       *string                 `json:"name,omitempty"`

--- a/api/kbcloud/model_engine_definition_detail.go
+++ b/api/kbcloud/model_engine_definition_detail.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type EngineDefinitionDetail struct {
 	DefinitionName *string `json:"definitionName,omitempty"`

--- a/api/kbcloud/model_engine_definition_version.go
+++ b/api/kbcloud/model_engine_definition_version.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type EngineDefinitionVersion struct {
 	Version common.NullableString         `json:"version,omitempty"`

--- a/api/kbcloud/model_engine_definition_version_query.go
+++ b/api/kbcloud/model_engine_definition_version_query.go
@@ -4,13 +4,17 @@
 
 package kbcloud
 
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
 type EngineDefinitionVersionQuery struct {
 	// the query to get the version, if not provided, will use inherited query from engine definition
-	Sql    common.NullableString `json:"sql,omitempty"`
-	Column common.NullableString `json:"column,omitempty"`
-	Regex  common.NullableString `json:"regex,omitempty"`
-	Min    common.NullableFloat  `json:"min,omitempty"`
-	Max    common.NullableFloat  `json:"max,omitempty"`
+	Sql    common.NullableString  `json:"sql,omitempty"`
+	Column common.NullableString  `json:"column,omitempty"`
+	Regex  common.NullableString  `json:"regex,omitempty"`
+	Min    common.NullableFloat64 `json:"min,omitempty"`
+	Max    common.NullableFloat64 `json:"max,omitempty"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
 	UnparsedObject       map[string]interface{} `json:"-"`
 	AdditionalProperties map[string]interface{} `json:"-"`
@@ -151,9 +155,9 @@ func (o *EngineDefinitionVersionQuery) UnsetRegex() {
 }
 
 // GetMin returns the Min field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *EngineDefinitionVersionQuery) GetMin() float {
+func (o *EngineDefinitionVersionQuery) GetMin() float64 {
 	if o == nil || o.Min.Get() == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return *o.Min.Get()
@@ -162,7 +166,7 @@ func (o *EngineDefinitionVersionQuery) GetMin() float {
 // GetMinOk returns a tuple with the Min field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned.
-func (o *EngineDefinitionVersionQuery) GetMinOk() (*float, bool) {
+func (o *EngineDefinitionVersionQuery) GetMinOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -174,8 +178,8 @@ func (o *EngineDefinitionVersionQuery) HasMin() bool {
 	return o != nil && o.Min.IsSet()
 }
 
-// SetMin gets a reference to the given common.NullableFloat and assigns it to the Min field.
-func (o *EngineDefinitionVersionQuery) SetMin(v float) {
+// SetMin gets a reference to the given common.NullableFloat64 and assigns it to the Min field.
+func (o *EngineDefinitionVersionQuery) SetMin(v float64) {
 	o.Min.Set(&v)
 }
 
@@ -190,9 +194,9 @@ func (o *EngineDefinitionVersionQuery) UnsetMin() {
 }
 
 // GetMax returns the Max field value if set, zero value otherwise (both if not set or set to explicit null).
-func (o *EngineDefinitionVersionQuery) GetMax() float {
+func (o *EngineDefinitionVersionQuery) GetMax() float64 {
 	if o == nil || o.Max.Get() == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return *o.Max.Get()
@@ -201,7 +205,7 @@ func (o *EngineDefinitionVersionQuery) GetMax() float {
 // GetMaxOk returns a tuple with the Max field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 // NOTE: If the value is an explicit nil, `nil, true` will be returned.
-func (o *EngineDefinitionVersionQuery) GetMaxOk() (*float, bool) {
+func (o *EngineDefinitionVersionQuery) GetMaxOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -213,8 +217,8 @@ func (o *EngineDefinitionVersionQuery) HasMax() bool {
 	return o != nil && o.Max.IsSet()
 }
 
-// SetMax gets a reference to the given common.NullableFloat and assigns it to the Max field.
-func (o *EngineDefinitionVersionQuery) SetMax(v float) {
+// SetMax gets a reference to the given common.NullableFloat64 and assigns it to the Max field.
+func (o *EngineDefinitionVersionQuery) SetMax(v float64) {
 	o.Max.Set(&v)
 }
 
@@ -259,11 +263,11 @@ func (o EngineDefinitionVersionQuery) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *EngineDefinitionVersionQuery) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Sql    common.NullableString `json:"sql,omitempty"`
-		Column common.NullableString `json:"column,omitempty"`
-		Regex  common.NullableString `json:"regex,omitempty"`
-		Min    common.NullableFloat  `json:"min,omitempty"`
-		Max    common.NullableFloat  `json:"max,omitempty"`
+		Sql    common.NullableString  `json:"sql,omitempty"`
+		Column common.NullableString  `json:"column,omitempty"`
+		Regex  common.NullableString  `json:"regex,omitempty"`
+		Min    common.NullableFloat64 `json:"min,omitempty"`
+		Max    common.NullableFloat64 `json:"max,omitempty"`
 	}{}
 	if err = common.Unmarshal(bytes, &all); err != nil {
 		return err

--- a/api/kbcloud/model_engine_list.go
+++ b/api/kbcloud/model_engine_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type EngineList struct {
+	Items []Engine
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewEngineList instantiates a new EngineList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewEngineList() *EngineList {
+	this := EngineList{}
+	return &this
+}
+
+// NewEngineListWithDefaults instantiates a new EngineList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewEngineListWithDefaults() *EngineList {
+	this := EngineList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o EngineList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *EngineList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_engine_mapping.go
+++ b/api/kbcloud/model_engine_mapping.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type EngineMapping struct {
 	Source              *string                    `json:"source,omitempty"`

--- a/api/kbcloud/model_environment_pricing.go
+++ b/api/kbcloud/model_environment_pricing.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // EnvironmentPricing the information of environment pricing
 type EnvironmentPricing struct {

--- a/api/kbcloud/model_import_boolean_field.go
+++ b/api/kbcloud/model_import_boolean_field.go
@@ -4,14 +4,16 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportBooleanField Configuration for a boolean-type field.
 type ImportBooleanField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -21,7 +23,7 @@ type ImportBooleanField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type    ImportFieldType     `json:"type,omitempty"`
+	Type    *ImportFieldType    `json:"type,omitempty"`
 	Default common.NullableBool `json:"default,omitempty"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
 	UnparsedObject       map[string]interface{} `json:"-"`
@@ -47,7 +49,7 @@ func (o *ImportBooleanField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -56,7 +58,7 @@ func (o *ImportBooleanField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -66,7 +68,7 @@ func (o *ImportBooleanField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportBooleanField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -75,7 +77,7 @@ func (o *ImportBooleanField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -84,7 +86,7 @@ func (o *ImportBooleanField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -94,7 +96,7 @@ func (o *ImportBooleanField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportBooleanField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -215,7 +217,7 @@ func (o *ImportBooleanField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -224,7 +226,7 @@ func (o *ImportBooleanField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -234,7 +236,7 @@ func (o *ImportBooleanField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportBooleanField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetDefault returns the Default field value if set, zero value otherwise.
@@ -315,13 +317,13 @@ func (o ImportBooleanField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportBooleanField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string              `json:"name,omitempty"`
-		Label       string              `json:"label,omitempty"`
+		Name        *string             `json:"name,omitempty"`
+		Label       *string             `json:"label,omitempty"`
 		Required    *bool               `json:"required,omitempty"`
 		Sensitive   *bool               `json:"sensitive,omitempty"`
 		Description *string             `json:"description,omitempty"`
 		Placeholder *string             `json:"placeholder,omitempty"`
-		Type        ImportFieldType     `json:"type,omitempty"`
+		Type        *ImportFieldType    `json:"type,omitempty"`
 		Default     common.NullableBool `json:"default,omitempty"`
 	}{}
 	if err = common.Unmarshal(bytes, &all); err != nil {

--- a/api/kbcloud/model_import_connection_field.go
+++ b/api/kbcloud/model_import_connection_field.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportConnectionField - Connection field configuration. Use `oneOf` to enforce strict type-specific properties.
 type ImportConnectionField struct {

--- a/api/kbcloud/model_import_enum_field.go
+++ b/api/kbcloud/model_import_enum_field.go
@@ -4,14 +4,16 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportEnumField Configuration for an enum-type field.
 type ImportEnumField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -21,7 +23,7 @@ type ImportEnumField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type ImportFieldType `json:"type,omitempty"`
+	Type *ImportFieldType `json:"type,omitempty"`
 	// List of available options for the enum.
 	Options []string              `json:"options,omitempty"`
 	Default common.NullableString `json:"default,omitempty"`
@@ -49,7 +51,7 @@ func (o *ImportEnumField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -58,7 +60,7 @@ func (o *ImportEnumField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -68,7 +70,7 @@ func (o *ImportEnumField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportEnumField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -77,7 +79,7 @@ func (o *ImportEnumField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -86,7 +88,7 @@ func (o *ImportEnumField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -96,7 +98,7 @@ func (o *ImportEnumField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportEnumField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -217,7 +219,7 @@ func (o *ImportEnumField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -226,7 +228,7 @@ func (o *ImportEnumField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -236,7 +238,7 @@ func (o *ImportEnumField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportEnumField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetOptions returns the Options field value if set, zero value otherwise.
@@ -348,13 +350,13 @@ func (o ImportEnumField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportEnumField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string                `json:"name,omitempty"`
-		Label       string                `json:"label,omitempty"`
+		Name        *string               `json:"name,omitempty"`
+		Label       *string               `json:"label,omitempty"`
 		Required    *bool                 `json:"required,omitempty"`
 		Sensitive   *bool                 `json:"sensitive,omitempty"`
 		Description *string               `json:"description,omitempty"`
 		Placeholder *string               `json:"placeholder,omitempty"`
-		Type        ImportFieldType       `json:"type,omitempty"`
+		Type        *ImportFieldType      `json:"type,omitempty"`
 		Options     []string              `json:"options,omitempty"`
 		Default     common.NullableString `json:"default,omitempty"`
 	}{}

--- a/api/kbcloud/model_import_field_type.go
+++ b/api/kbcloud/model_import_field_type.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"fmt"
+
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+// ImportFieldType Import field type
+type ImportFieldType string
+
+// List of ImportFieldType.
+const (
+	ImportFieldTypeString  ImportFieldType = "string"
+	ImportFieldTypeInteger ImportFieldType = "integer"
+	ImportFieldTypeNumber  ImportFieldType = "number"
+	ImportFieldTypeBoolean ImportFieldType = "boolean"
+	ImportFieldTypeEnum    ImportFieldType = "enum"
+)
+
+var allowedImportFieldTypeEnumValues = []ImportFieldType{
+	ImportFieldTypeString,
+	ImportFieldTypeInteger,
+	ImportFieldTypeNumber,
+	ImportFieldTypeBoolean,
+	ImportFieldTypeEnum,
+}
+
+// GetAllowedValues returns the list of possible values.
+func (v *ImportFieldType) GetAllowedValues() []ImportFieldType {
+	return allowedImportFieldTypeEnumValues
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (v *ImportFieldType) UnmarshalJSON(src []byte) error {
+	var value string
+	err := common.Unmarshal(src, &value)
+	if err != nil {
+		return err
+	}
+	*v = ImportFieldType(value)
+	return nil
+}
+
+// NewImportFieldTypeFromValue returns a pointer to a valid ImportFieldType
+// for the value passed as argument, or an error if the value passed is not allowed by the enum.
+func NewImportFieldTypeFromValue(v string) (*ImportFieldType, error) {
+	ev := ImportFieldType(v)
+	if ev.IsValid() {
+		return &ev, nil
+	}
+	return nil, fmt.Errorf("invalid value '%v' for ImportFieldType: valid values are %v", v, allowedImportFieldTypeEnumValues)
+}
+
+// IsValid return true if the value is valid for the enum, false otherwise.
+func (v ImportFieldType) IsValid() bool {
+	for _, existing := range allowedImportFieldTypeEnumValues {
+		if existing == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Ptr returns reference to ImportFieldType value.
+func (v ImportFieldType) Ptr() *ImportFieldType {
+	return &v
+}

--- a/api/kbcloud/model_import_integer_field.go
+++ b/api/kbcloud/model_import_integer_field.go
@@ -4,14 +4,16 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportIntegerField Configuration for an integer-type field.
 type ImportIntegerField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -21,7 +23,7 @@ type ImportIntegerField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type    ImportFieldType      `json:"type,omitempty"`
+	Type    *ImportFieldType     `json:"type,omitempty"`
 	Default common.NullableInt32 `json:"default,omitempty"`
 	// Validation rules for numeric field type
 	Validation *ImportNumericValidation `json:"validation,omitempty"`
@@ -49,7 +51,7 @@ func (o *ImportIntegerField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -58,7 +60,7 @@ func (o *ImportIntegerField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -68,7 +70,7 @@ func (o *ImportIntegerField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportIntegerField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -77,7 +79,7 @@ func (o *ImportIntegerField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -86,7 +88,7 @@ func (o *ImportIntegerField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -96,7 +98,7 @@ func (o *ImportIntegerField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportIntegerField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -217,7 +219,7 @@ func (o *ImportIntegerField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -226,7 +228,7 @@ func (o *ImportIntegerField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -236,7 +238,7 @@ func (o *ImportIntegerField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportIntegerField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetDefault returns the Default field value if set, zero value otherwise.
@@ -348,13 +350,13 @@ func (o ImportIntegerField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportIntegerField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string                   `json:"name,omitempty"`
-		Label       string                   `json:"label,omitempty"`
+		Name        *string                  `json:"name,omitempty"`
+		Label       *string                  `json:"label,omitempty"`
 		Required    *bool                    `json:"required,omitempty"`
 		Sensitive   *bool                    `json:"sensitive,omitempty"`
 		Description *string                  `json:"description,omitempty"`
 		Placeholder *string                  `json:"placeholder,omitempty"`
-		Type        ImportFieldType          `json:"type,omitempty"`
+		Type        *ImportFieldType         `json:"type,omitempty"`
 		Default     common.NullableInt32     `json:"default,omitempty"`
 		Validation  *ImportNumericValidation `json:"validation,omitempty"`
 	}{}
@@ -380,6 +382,9 @@ func (o *ImportIntegerField) UnmarshalJSON(bytes []byte) (err error) {
 		o.Type = all.Type
 	}
 	o.Default = all.Default
+	if all.Validation != nil && all.Validation.UnparsedObject != nil && o.UnparsedObject == nil {
+		hasInvalidField = true
+	}
 	o.Validation = all.Validation
 	if len(additionalProperties) > 0 {
 		o.AdditionalProperties = additionalProperties

--- a/api/kbcloud/model_import_number_field.go
+++ b/api/kbcloud/model_import_number_field.go
@@ -4,12 +4,16 @@
 
 package kbcloud
 
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
 // ImportNumberField Configuration for a number-type field.
 type ImportNumberField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -19,8 +23,8 @@ type ImportNumberField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type    ImportFieldType      `json:"type,omitempty"`
-	Default common.NullableFloat `json:"default,omitempty"`
+	Type    *ImportFieldType       `json:"type,omitempty"`
+	Default common.NullableFloat64 `json:"default,omitempty"`
 	// Validation rules for numeric field type
 	Validation *ImportNumericValidation `json:"validation,omitempty"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
@@ -47,7 +51,7 @@ func (o *ImportNumberField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -56,7 +60,7 @@ func (o *ImportNumberField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -66,7 +70,7 @@ func (o *ImportNumberField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportNumberField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -75,7 +79,7 @@ func (o *ImportNumberField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -84,7 +88,7 @@ func (o *ImportNumberField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -94,7 +98,7 @@ func (o *ImportNumberField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportNumberField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -215,7 +219,7 @@ func (o *ImportNumberField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -224,7 +228,7 @@ func (o *ImportNumberField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -234,13 +238,13 @@ func (o *ImportNumberField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportNumberField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetDefault returns the Default field value if set, zero value otherwise.
-func (o *ImportNumberField) GetDefault() float {
+func (o *ImportNumberField) GetDefault() float64 {
 	if o == nil || o.Default.Get() == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return *o.Default.Get()
@@ -248,7 +252,7 @@ func (o *ImportNumberField) GetDefault() float {
 
 // GetDefaultOk returns a tuple with the Default field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ImportNumberField) GetDefaultOk() (*float, bool) {
+func (o *ImportNumberField) GetDefaultOk() (*float64, bool) {
 	if o == nil || o.Default.Get() == nil {
 		return nil, false
 	}
@@ -260,8 +264,8 @@ func (o *ImportNumberField) HasDefault() bool {
 	return o != nil && o.Default.IsSet()
 }
 
-// SetDefault gets a reference to the given common.NullableFloat and assigns it to the Default field.
-func (o *ImportNumberField) SetDefault(v float) {
+// SetDefault gets a reference to the given common.NullableFloat64 and assigns it to the Default field.
+func (o *ImportNumberField) SetDefault(v float64) {
 	o.Default.Set(&v)
 }
 
@@ -346,14 +350,14 @@ func (o ImportNumberField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportNumberField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string                   `json:"name,omitempty"`
-		Label       string                   `json:"label,omitempty"`
+		Name        *string                  `json:"name,omitempty"`
+		Label       *string                  `json:"label,omitempty"`
 		Required    *bool                    `json:"required,omitempty"`
 		Sensitive   *bool                    `json:"sensitive,omitempty"`
 		Description *string                  `json:"description,omitempty"`
 		Placeholder *string                  `json:"placeholder,omitempty"`
-		Type        ImportFieldType          `json:"type,omitempty"`
-		Default     common.NullableFloat     `json:"default,omitempty"`
+		Type        *ImportFieldType         `json:"type,omitempty"`
+		Default     common.NullableFloat64   `json:"default,omitempty"`
 		Validation  *ImportNumericValidation `json:"validation,omitempty"`
 	}{}
 	if err = common.Unmarshal(bytes, &all); err != nil {
@@ -378,6 +382,9 @@ func (o *ImportNumberField) UnmarshalJSON(bytes []byte) (err error) {
 		o.Type = all.Type
 	}
 	o.Default = all.Default
+	if all.Validation != nil && all.Validation.UnparsedObject != nil && o.UnparsedObject == nil {
+		hasInvalidField = true
+	}
 	o.Validation = all.Validation
 	if len(additionalProperties) > 0 {
 		o.AdditionalProperties = additionalProperties

--- a/api/kbcloud/model_import_numeric_validation.go
+++ b/api/kbcloud/model_import_numeric_validation.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// ImportNumericValidation Validation rules for numeric field type
+type ImportNumericValidation struct {
+	// Minimum value
+	Min *float64 `json:"min,omitempty"`
+	// Maximum value
+	Max *float64 `json:"max,omitempty"`
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewImportNumericValidation instantiates a new ImportNumericValidation object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewImportNumericValidation() *ImportNumericValidation {
+	this := ImportNumericValidation{}
+	return &this
+}
+
+// NewImportNumericValidationWithDefaults instantiates a new ImportNumericValidation object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewImportNumericValidationWithDefaults() *ImportNumericValidation {
+	this := ImportNumericValidation{}
+	return &this
+}
+
+// GetMin returns the Min field value if set, zero value otherwise.
+func (o *ImportNumericValidation) GetMin() float64 {
+	if o == nil || o.Min == nil {
+		var ret float64
+		return ret
+	}
+	return *o.Min
+}
+
+// GetMinOk returns a tuple with the Min field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportNumericValidation) GetMinOk() (*float64, bool) {
+	if o == nil || o.Min == nil {
+		return nil, false
+	}
+	return o.Min, true
+}
+
+// HasMin returns a boolean if a field has been set.
+func (o *ImportNumericValidation) HasMin() bool {
+	return o != nil && o.Min != nil
+}
+
+// SetMin gets a reference to the given float64 and assigns it to the Min field.
+func (o *ImportNumericValidation) SetMin(v float64) {
+	o.Min = &v
+}
+
+// GetMax returns the Max field value if set, zero value otherwise.
+func (o *ImportNumericValidation) GetMax() float64 {
+	if o == nil || o.Max == nil {
+		var ret float64
+		return ret
+	}
+	return *o.Max
+}
+
+// GetMaxOk returns a tuple with the Max field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportNumericValidation) GetMaxOk() (*float64, bool) {
+	if o == nil || o.Max == nil {
+		return nil, false
+	}
+	return o.Max, true
+}
+
+// HasMax returns a boolean if a field has been set.
+func (o *ImportNumericValidation) HasMax() bool {
+	return o != nil && o.Max != nil
+}
+
+// SetMax gets a reference to the given float64 and assigns it to the Max field.
+func (o *ImportNumericValidation) SetMax(v float64) {
+	o.Max = &v
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ImportNumericValidation) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	if o.Min != nil {
+		toSerialize["min"] = o.Min
+	}
+	if o.Max != nil {
+		toSerialize["max"] = o.Max
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ImportNumericValidation) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+		Min *float64 `json:"min,omitempty"`
+		Max *float64 `json:"max,omitempty"`
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{"min", "max"})
+	} else {
+		return err
+	}
+	o.Min = all.Min
+	o.Max = all.Max
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_import_option.go
+++ b/api/kbcloud/model_import_option.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ImportOption struct {
 	// List of supported data sources for import

--- a/api/kbcloud/model_import_string_field.go
+++ b/api/kbcloud/model_import_string_field.go
@@ -4,14 +4,16 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // ImportStringField Configuration for a string-type field.
 type ImportStringField struct {
 	// Field's programmatic name (e.g., 'db_host')
-	Name string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty"`
 	// User-facing label for UI (e.g., 'Database Host')
-	Label string `json:"label,omitempty"`
+	Label *string `json:"label,omitempty"`
 	// Whether the field is required
 	Required *bool `json:"required,omitempty"`
 	// Whether it contains sensitive information (e.g., password)
@@ -21,7 +23,7 @@ type ImportStringField struct {
 	// Placeholder text for the input
 	Placeholder *string `json:"placeholder,omitempty"`
 	// Import field type
-	Type    ImportFieldType       `json:"type,omitempty"`
+	Type    *ImportFieldType      `json:"type,omitempty"`
 	Default common.NullableString `json:"default,omitempty"`
 	// Validation rules for string field type
 	Validation *ImportStringValidation `json:"validation,omitempty"`
@@ -49,7 +51,7 @@ func (o *ImportStringField) GetName() string {
 		var ret string
 		return ret
 	}
-	return o.Name
+	return *o.Name
 }
 
 // GetNameOk returns a tuple with the Name field value if set, nil otherwise
@@ -58,7 +60,7 @@ func (o *ImportStringField) GetNameOk() (*string, bool) {
 	if o == nil || o.Name == nil {
 		return nil, false
 	}
-	return &o.Name, true
+	return o.Name, true
 }
 
 // HasName returns a boolean if a field has been set.
@@ -68,7 +70,7 @@ func (o *ImportStringField) HasName() bool {
 
 // SetName gets a reference to the given string and assigns it to the Name field.
 func (o *ImportStringField) SetName(v string) {
-	o.Name = v
+	o.Name = &v
 }
 
 // GetLabel returns the Label field value if set, zero value otherwise.
@@ -77,7 +79,7 @@ func (o *ImportStringField) GetLabel() string {
 		var ret string
 		return ret
 	}
-	return o.Label
+	return *o.Label
 }
 
 // GetLabelOk returns a tuple with the Label field value if set, nil otherwise
@@ -86,7 +88,7 @@ func (o *ImportStringField) GetLabelOk() (*string, bool) {
 	if o == nil || o.Label == nil {
 		return nil, false
 	}
-	return &o.Label, true
+	return o.Label, true
 }
 
 // HasLabel returns a boolean if a field has been set.
@@ -96,7 +98,7 @@ func (o *ImportStringField) HasLabel() bool {
 
 // SetLabel gets a reference to the given string and assigns it to the Label field.
 func (o *ImportStringField) SetLabel(v string) {
-	o.Label = v
+	o.Label = &v
 }
 
 // GetRequired returns the Required field value if set, zero value otherwise.
@@ -217,7 +219,7 @@ func (o *ImportStringField) GetType() ImportFieldType {
 		var ret ImportFieldType
 		return ret
 	}
-	return o.Type
+	return *o.Type
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
@@ -226,7 +228,7 @@ func (o *ImportStringField) GetTypeOk() (*ImportFieldType, bool) {
 	if o == nil || o.Type == nil {
 		return nil, false
 	}
-	return &o.Type, true
+	return o.Type, true
 }
 
 // HasType returns a boolean if a field has been set.
@@ -236,7 +238,7 @@ func (o *ImportStringField) HasType() bool {
 
 // SetType gets a reference to the given ImportFieldType and assigns it to the Type field.
 func (o *ImportStringField) SetType(v ImportFieldType) {
-	o.Type = v
+	o.Type = &v
 }
 
 // GetDefault returns the Default field value if set, zero value otherwise.
@@ -348,13 +350,13 @@ func (o ImportStringField) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *ImportStringField) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Name        string                  `json:"name,omitempty"`
-		Label       string                  `json:"label,omitempty"`
+		Name        *string                 `json:"name,omitempty"`
+		Label       *string                 `json:"label,omitempty"`
 		Required    *bool                   `json:"required,omitempty"`
 		Sensitive   *bool                   `json:"sensitive,omitempty"`
 		Description *string                 `json:"description,omitempty"`
 		Placeholder *string                 `json:"placeholder,omitempty"`
-		Type        ImportFieldType         `json:"type,omitempty"`
+		Type        *ImportFieldType        `json:"type,omitempty"`
 		Default     common.NullableString   `json:"default,omitempty"`
 		Validation  *ImportStringValidation `json:"validation,omitempty"`
 	}{}
@@ -380,6 +382,9 @@ func (o *ImportStringField) UnmarshalJSON(bytes []byte) (err error) {
 		o.Type = all.Type
 	}
 	o.Default = all.Default
+	if all.Validation != nil && all.Validation.UnparsedObject != nil && o.UnparsedObject == nil {
+		hasInvalidField = true
+	}
 	o.Validation = all.Validation
 	if len(additionalProperties) > 0 {
 		o.AdditionalProperties = additionalProperties

--- a/api/kbcloud/model_import_string_validation.go
+++ b/api/kbcloud/model_import_string_validation.go
@@ -1,0 +1,170 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// ImportStringValidation Validation rules for string field type
+type ImportStringValidation struct {
+	// Minimum length
+	MinLength *int32 `json:"minLength,omitempty"`
+	// Maximum length
+	MaxLength *int32 `json:"maxLength,omitempty"`
+	// Regex pattern
+	Pattern *string `json:"pattern,omitempty"`
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewImportStringValidation instantiates a new ImportStringValidation object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewImportStringValidation() *ImportStringValidation {
+	this := ImportStringValidation{}
+	return &this
+}
+
+// NewImportStringValidationWithDefaults instantiates a new ImportStringValidation object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewImportStringValidationWithDefaults() *ImportStringValidation {
+	this := ImportStringValidation{}
+	return &this
+}
+
+// GetMinLength returns the MinLength field value if set, zero value otherwise.
+func (o *ImportStringValidation) GetMinLength() int32 {
+	if o == nil || o.MinLength == nil {
+		var ret int32
+		return ret
+	}
+	return *o.MinLength
+}
+
+// GetMinLengthOk returns a tuple with the MinLength field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportStringValidation) GetMinLengthOk() (*int32, bool) {
+	if o == nil || o.MinLength == nil {
+		return nil, false
+	}
+	return o.MinLength, true
+}
+
+// HasMinLength returns a boolean if a field has been set.
+func (o *ImportStringValidation) HasMinLength() bool {
+	return o != nil && o.MinLength != nil
+}
+
+// SetMinLength gets a reference to the given int32 and assigns it to the MinLength field.
+func (o *ImportStringValidation) SetMinLength(v int32) {
+	o.MinLength = &v
+}
+
+// GetMaxLength returns the MaxLength field value if set, zero value otherwise.
+func (o *ImportStringValidation) GetMaxLength() int32 {
+	if o == nil || o.MaxLength == nil {
+		var ret int32
+		return ret
+	}
+	return *o.MaxLength
+}
+
+// GetMaxLengthOk returns a tuple with the MaxLength field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportStringValidation) GetMaxLengthOk() (*int32, bool) {
+	if o == nil || o.MaxLength == nil {
+		return nil, false
+	}
+	return o.MaxLength, true
+}
+
+// HasMaxLength returns a boolean if a field has been set.
+func (o *ImportStringValidation) HasMaxLength() bool {
+	return o != nil && o.MaxLength != nil
+}
+
+// SetMaxLength gets a reference to the given int32 and assigns it to the MaxLength field.
+func (o *ImportStringValidation) SetMaxLength(v int32) {
+	o.MaxLength = &v
+}
+
+// GetPattern returns the Pattern field value if set, zero value otherwise.
+func (o *ImportStringValidation) GetPattern() string {
+	if o == nil || o.Pattern == nil {
+		var ret string
+		return ret
+	}
+	return *o.Pattern
+}
+
+// GetPatternOk returns a tuple with the Pattern field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ImportStringValidation) GetPatternOk() (*string, bool) {
+	if o == nil || o.Pattern == nil {
+		return nil, false
+	}
+	return o.Pattern, true
+}
+
+// HasPattern returns a boolean if a field has been set.
+func (o *ImportStringValidation) HasPattern() bool {
+	return o != nil && o.Pattern != nil
+}
+
+// SetPattern gets a reference to the given string and assigns it to the Pattern field.
+func (o *ImportStringValidation) SetPattern(v string) {
+	o.Pattern = &v
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ImportStringValidation) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	if o.MinLength != nil {
+		toSerialize["minLength"] = o.MinLength
+	}
+	if o.MaxLength != nil {
+		toSerialize["maxLength"] = o.MaxLength
+	}
+	if o.Pattern != nil {
+		toSerialize["pattern"] = o.Pattern
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ImportStringValidation) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+		MinLength *int32  `json:"minLength,omitempty"`
+		MaxLength *int32  `json:"maxLength,omitempty"`
+		Pattern   *string `json:"pattern,omitempty"`
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{"minLength", "maxLength", "pattern"})
+	} else {
+		return err
+	}
+	o.MinLength = all.MinLength
+	o.MaxLength = all.MaxLength
+	o.Pattern = all.Pattern
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_init_options.go
+++ b/api/kbcloud/model_init_options.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// InitOptions InitOptions is the list of init option
+type InitOptions struct {
+	Items []InitOptionItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewInitOptions instantiates a new InitOptions object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewInitOptions() *InitOptions {
+	this := InitOptions{}
+	return &this
+}
+
+// NewInitOptionsWithDefaults instantiates a new InitOptions object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewInitOptionsWithDefaults() *InitOptions {
+	this := InitOptions{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o InitOptions) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *InitOptions) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_io_quantity.go
+++ b/api/kbcloud/model_io_quantity.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // IoQuantity IO Quantity describes IOPS and BPS of a volume
 type IoQuantity struct {

--- a/api/kbcloud/model_metadata_object.go
+++ b/api/kbcloud/model_metadata_object.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// MetadataObject Optional metadata for AI messages (e.g., tool calls, results)
+type MetadataObject struct {
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewMetadataObject instantiates a new MetadataObject object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewMetadataObject() *MetadataObject {
+	this := MetadataObject{}
+	return &this
+}
+
+// NewMetadataObjectWithDefaults instantiates a new MetadataObject object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewMetadataObjectWithDefaults() *MetadataObject {
+	this := MetadataObject{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o MetadataObject) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *MetadataObject) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{})
+	} else {
+		return err
+	}
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_module_definition.go
+++ b/api/kbcloud/model_module_definition.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ModuleDefinition struct {
 	Name   *string                  `json:"name,omitempty"`

--- a/api/kbcloud/model_module_definition_values.go
+++ b/api/kbcloud/model_module_definition_values.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ModuleDefinitionValues struct {
 	ModuleValue *string                `json:"moduleValue,omitempty"`

--- a/api/kbcloud/model_network_mode_option.go
+++ b/api/kbcloud/model_network_mode_option.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type NetworkModeOption struct {
+	Items []NetworkModeOptionItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewNetworkModeOption instantiates a new NetworkModeOption object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewNetworkModeOption() *NetworkModeOption {
+	this := NetworkModeOption{}
+	return &this
+}
+
+// NewNetworkModeOptionWithDefaults instantiates a new NetworkModeOption object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewNetworkModeOptionWithDefaults() *NetworkModeOption {
+	this := NetworkModeOption{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o NetworkModeOption) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *NetworkModeOption) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_org_parameter_list.go
+++ b/api/kbcloud/model_org_parameter_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// OrgParameterList org parameter list
+type OrgParameterList struct {
+	Items []OrgParameter
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewOrgParameterList instantiates a new OrgParameterList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewOrgParameterList() *OrgParameterList {
+	this := OrgParameterList{}
+	return &this
+}
+
+// NewOrgParameterListWithDefaults instantiates a new OrgParameterList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewOrgParameterListWithDefaults() *OrgParameterList {
+	this := OrgParameterList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o OrgParameterList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *OrgParameterList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_org_resource_quota.go
+++ b/api/kbcloud/model_org_resource_quota.go
@@ -13,11 +13,11 @@ import (
 // OrgResourceQuota org resource quota
 type OrgResourceQuota struct {
 	// Maximum available vCPU. if set to 0, no limit
-	Cpu float `json:"cpu"`
+	Cpu float64 `json:"cpu"`
 	// Maximum available memory in GB. if set to 0, no limit
-	Memory float `json:"memory"`
+	Memory float64 `json:"memory"`
 	// Maximum available storage in GB. if set to 0, no limit
-	Storage float `json:"storage"`
+	Storage float64 `json:"storage"`
 	// Number of the clusters. key is engine type, values is the maximum number of engine
 	Clusters map[string]int32 `json:"clusters"`
 	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
@@ -29,7 +29,7 @@ type OrgResourceQuota struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed.
-func NewOrgResourceQuota(cpu float, memory float, storage float, clusters map[string]int32) *OrgResourceQuota {
+func NewOrgResourceQuota(cpu float64, memory float64, storage float64, clusters map[string]int32) *OrgResourceQuota {
 	this := OrgResourceQuota{}
 	this.Cpu = cpu
 	this.Memory = memory
@@ -47,9 +47,9 @@ func NewOrgResourceQuotaWithDefaults() *OrgResourceQuota {
 }
 
 // GetCpu returns the Cpu field value.
-func (o *OrgResourceQuota) GetCpu() float {
+func (o *OrgResourceQuota) GetCpu() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Cpu
@@ -57,7 +57,7 @@ func (o *OrgResourceQuota) GetCpu() float {
 
 // GetCpuOk returns a tuple with the Cpu field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuota) GetCpuOk() (*float, bool) {
+func (o *OrgResourceQuota) GetCpuOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -65,14 +65,14 @@ func (o *OrgResourceQuota) GetCpuOk() (*float, bool) {
 }
 
 // SetCpu sets field value.
-func (o *OrgResourceQuota) SetCpu(v float) {
+func (o *OrgResourceQuota) SetCpu(v float64) {
 	o.Cpu = v
 }
 
 // GetMemory returns the Memory field value.
-func (o *OrgResourceQuota) GetMemory() float {
+func (o *OrgResourceQuota) GetMemory() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Memory
@@ -80,7 +80,7 @@ func (o *OrgResourceQuota) GetMemory() float {
 
 // GetMemoryOk returns a tuple with the Memory field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuota) GetMemoryOk() (*float, bool) {
+func (o *OrgResourceQuota) GetMemoryOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -88,14 +88,14 @@ func (o *OrgResourceQuota) GetMemoryOk() (*float, bool) {
 }
 
 // SetMemory sets field value.
-func (o *OrgResourceQuota) SetMemory(v float) {
+func (o *OrgResourceQuota) SetMemory(v float64) {
 	o.Memory = v
 }
 
 // GetStorage returns the Storage field value.
-func (o *OrgResourceQuota) GetStorage() float {
+func (o *OrgResourceQuota) GetStorage() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Storage
@@ -103,7 +103,7 @@ func (o *OrgResourceQuota) GetStorage() float {
 
 // GetStorageOk returns a tuple with the Storage field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuota) GetStorageOk() (*float, bool) {
+func (o *OrgResourceQuota) GetStorageOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -111,7 +111,7 @@ func (o *OrgResourceQuota) GetStorageOk() (*float, bool) {
 }
 
 // SetStorage sets field value.
-func (o *OrgResourceQuota) SetStorage(v float) {
+func (o *OrgResourceQuota) SetStorage(v float64) {
 	o.Storage = v
 }
 
@@ -158,9 +158,9 @@ func (o OrgResourceQuota) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *OrgResourceQuota) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Cpu      *float            `json:"cpu"`
-		Memory   *float            `json:"memory"`
-		Storage  *float            `json:"storage"`
+		Cpu      *float64          `json:"cpu"`
+		Memory   *float64          `json:"memory"`
+		Storage  *float64          `json:"storage"`
 		Clusters *map[string]int32 `json:"clusters"`
 	}{}
 	if err = common.Unmarshal(bytes, &all); err != nil {

--- a/api/kbcloud/model_org_resource_quota_and_usage.go
+++ b/api/kbcloud/model_org_resource_quota_and_usage.go
@@ -13,11 +13,11 @@ import (
 // OrgResourceQuotaAndUsage org resource quota
 type OrgResourceQuotaAndUsage struct {
 	// Maximum available vCPU. if set to 0, no limit
-	Cpu float `json:"cpu"`
+	Cpu float64 `json:"cpu"`
 	// Maximum available memory in GB. if set to 0, no limit
-	Memory float `json:"memory"`
+	Memory float64 `json:"memory"`
 	// Maximum available storage in GB. if set to 0, no limit
-	Storage float `json:"storage"`
+	Storage float64 `json:"storage"`
 	// Number of the clusters. key is engine type, values is the maximum number of engine
 	Clusters map[string]int32 `json:"clusters"`
 	// org resource quota
@@ -31,7 +31,7 @@ type OrgResourceQuotaAndUsage struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed.
-func NewOrgResourceQuotaAndUsage(cpu float, memory float, storage float, clusters map[string]int32, usage OrgResourceQuota) *OrgResourceQuotaAndUsage {
+func NewOrgResourceQuotaAndUsage(cpu float64, memory float64, storage float64, clusters map[string]int32, usage OrgResourceQuota) *OrgResourceQuotaAndUsage {
 	this := OrgResourceQuotaAndUsage{}
 	this.Cpu = cpu
 	this.Memory = memory
@@ -50,9 +50,9 @@ func NewOrgResourceQuotaAndUsageWithDefaults() *OrgResourceQuotaAndUsage {
 }
 
 // GetCpu returns the Cpu field value.
-func (o *OrgResourceQuotaAndUsage) GetCpu() float {
+func (o *OrgResourceQuotaAndUsage) GetCpu() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Cpu
@@ -60,7 +60,7 @@ func (o *OrgResourceQuotaAndUsage) GetCpu() float {
 
 // GetCpuOk returns a tuple with the Cpu field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuotaAndUsage) GetCpuOk() (*float, bool) {
+func (o *OrgResourceQuotaAndUsage) GetCpuOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -68,14 +68,14 @@ func (o *OrgResourceQuotaAndUsage) GetCpuOk() (*float, bool) {
 }
 
 // SetCpu sets field value.
-func (o *OrgResourceQuotaAndUsage) SetCpu(v float) {
+func (o *OrgResourceQuotaAndUsage) SetCpu(v float64) {
 	o.Cpu = v
 }
 
 // GetMemory returns the Memory field value.
-func (o *OrgResourceQuotaAndUsage) GetMemory() float {
+func (o *OrgResourceQuotaAndUsage) GetMemory() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Memory
@@ -83,7 +83,7 @@ func (o *OrgResourceQuotaAndUsage) GetMemory() float {
 
 // GetMemoryOk returns a tuple with the Memory field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuotaAndUsage) GetMemoryOk() (*float, bool) {
+func (o *OrgResourceQuotaAndUsage) GetMemoryOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -91,14 +91,14 @@ func (o *OrgResourceQuotaAndUsage) GetMemoryOk() (*float, bool) {
 }
 
 // SetMemory sets field value.
-func (o *OrgResourceQuotaAndUsage) SetMemory(v float) {
+func (o *OrgResourceQuotaAndUsage) SetMemory(v float64) {
 	o.Memory = v
 }
 
 // GetStorage returns the Storage field value.
-func (o *OrgResourceQuotaAndUsage) GetStorage() float {
+func (o *OrgResourceQuotaAndUsage) GetStorage() float64 {
 	if o == nil {
-		var ret float
+		var ret float64
 		return ret
 	}
 	return o.Storage
@@ -106,7 +106,7 @@ func (o *OrgResourceQuotaAndUsage) GetStorage() float {
 
 // GetStorageOk returns a tuple with the Storage field value
 // and a boolean to check if the value has been set.
-func (o *OrgResourceQuotaAndUsage) GetStorageOk() (*float, bool) {
+func (o *OrgResourceQuotaAndUsage) GetStorageOk() (*float64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -114,7 +114,7 @@ func (o *OrgResourceQuotaAndUsage) GetStorageOk() (*float, bool) {
 }
 
 // SetStorage sets field value.
-func (o *OrgResourceQuotaAndUsage) SetStorage(v float) {
+func (o *OrgResourceQuotaAndUsage) SetStorage(v float64) {
 	o.Storage = v
 }
 
@@ -185,9 +185,9 @@ func (o OrgResourceQuotaAndUsage) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON deserializes the given payload.
 func (o *OrgResourceQuotaAndUsage) UnmarshalJSON(bytes []byte) (err error) {
 	all := struct {
-		Cpu      *float            `json:"cpu"`
-		Memory   *float            `json:"memory"`
-		Storage  *float            `json:"storage"`
+		Cpu      *float64          `json:"cpu"`
+		Memory   *float64          `json:"memory"`
+		Storage  *float64          `json:"storage"`
 		Clusters *map[string]int32 `json:"clusters"`
 		Usage    *OrgResourceQuota `json:"usage"`
 	}{}

--- a/api/kbcloud/model_param_tpls.go
+++ b/api/kbcloud/model_param_tpls.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// ParamTpls Items is the list of parameter template in the list
+type ParamTpls struct {
+	Items []ParamTplsItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewParamTpls instantiates a new ParamTpls object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewParamTpls() *ParamTpls {
+	this := ParamTpls{}
+	return &this
+}
+
+// NewParamTplsWithDefaults instantiates a new ParamTpls object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewParamTplsWithDefaults() *ParamTpls {
+	this := ParamTpls{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o ParamTpls) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *ParamTpls) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_partition_list.go
+++ b/api/kbcloud/model_partition_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type PartitionList struct {
+	Items []Partition
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewPartitionList instantiates a new PartitionList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewPartitionList() *PartitionList {
+	this := PartitionList{}
+	return &this
+}
+
+// NewPartitionListWithDefaults instantiates a new PartitionList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewPartitionListWithDefaults() *PartitionList {
+	this := PartitionList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o PartitionList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *PartitionList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_phone_number.go
+++ b/api/kbcloud/model_phone_number.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// PhoneNumber The phonenumber for the user.
+type PhoneNumber struct {
+	// UnparsedObject contains the raw value of the object if there was an error when deserializing into the struct
+	UnparsedObject       map[string]interface{} `json:"-"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
+
+// NewPhoneNumber instantiates a new PhoneNumber object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewPhoneNumber() *PhoneNumber {
+	this := PhoneNumber{}
+	return &this
+}
+
+// NewPhoneNumberWithDefaults instantiates a new PhoneNumber object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewPhoneNumberWithDefaults() *PhoneNumber {
+	this := PhoneNumber{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o PhoneNumber) MarshalJSON() ([]byte, error) {
+	toSerialize := map[string]interface{}{}
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+
+	for key, value := range o.AdditionalProperties {
+		toSerialize[key] = value
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *PhoneNumber) UnmarshalJSON(bytes []byte) (err error) {
+	all := struct {
+	}{}
+	if err = common.Unmarshal(bytes, &all); err != nil {
+		return err
+	}
+	additionalProperties := make(map[string]interface{})
+	if err = common.Unmarshal(bytes, &additionalProperties); err == nil {
+		common.DeleteKeys(additionalProperties, &[]string{})
+	} else {
+		return err
+	}
+
+	if len(additionalProperties) > 0 {
+		o.AdditionalProperties = additionalProperties
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_pre_check_create.go
+++ b/api/kbcloud/model_pre_check_create.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type PreCheckCreate struct {
 	Modules            []string                   `json:"modules,omitempty"`

--- a/api/kbcloud/model_pre_check_result.go
+++ b/api/kbcloud/model_pre_check_result.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type PreCheckResult struct {
 	Name        *string               `json:"name,omitempty"`

--- a/api/kbcloud/model_pre_check_task_item.go
+++ b/api/kbcloud/model_pre_check_task_item.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type PreCheckTaskItem struct {
 	CheckerName *string               `json:"checkerName,omitempty"`

--- a/api/kbcloud/model_privilege_list.go
+++ b/api/kbcloud/model_privilege_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// PrivilegeList A list of privileges and their databases.
+type PrivilegeList struct {
+	Items []PrivilegeListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewPrivilegeList instantiates a new PrivilegeList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewPrivilegeList() *PrivilegeList {
+	this := PrivilegeList{}
+	return &this
+}
+
+// NewPrivilegeListWithDefaults instantiates a new PrivilegeList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewPrivilegeListWithDefaults() *PrivilegeList {
+	this := PrivilegeList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o PrivilegeList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *PrivilegeList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_related_cluster_list.go
+++ b/api/kbcloud/model_related_cluster_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type RelatedClusterList struct {
+	Items []RelatedClusterListItem
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewRelatedClusterList instantiates a new RelatedClusterList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewRelatedClusterList() *RelatedClusterList {
+	this := RelatedClusterList{}
+	return &this
+}
+
+// NewRelatedClusterListWithDefaults instantiates a new RelatedClusterList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewRelatedClusterListWithDefaults() *RelatedClusterList {
+	this := RelatedClusterList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o RelatedClusterList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *RelatedClusterList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_replication_metadata_object.go
+++ b/api/kbcloud/model_replication_metadata_object.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ReplicationMetadataObject struct {
 	MetadataType *string                     `json:"metadataType,omitempty"`

--- a/api/kbcloud/model_replication_object_query.go
+++ b/api/kbcloud/model_replication_object_query.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ReplicationObjectQuery struct {
 	SourceEngineDefinition *string                    `json:"sourceEngineDefinition,omitempty"`

--- a/api/kbcloud/model_replication_object_tree.go
+++ b/api/kbcloud/model_replication_object_tree.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ReplicationObjectTree struct {
 	NodeType          *string                     `json:"nodeType,omitempty"`

--- a/api/kbcloud/model_show_data_request.go
+++ b/api/kbcloud/model_show_data_request.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type ShowDataRequest struct {
 	// the database of the table or view

--- a/api/kbcloud/model_standard_definition.go
+++ b/api/kbcloud/model_standard_definition.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type StandardDefinition struct {
 	Name        *string             `json:"name,omitempty"`

--- a/api/kbcloud/model_standard_resource.go
+++ b/api/kbcloud/model_standard_resource.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type StandardResource struct {
 	Limit   common.NullableFloat64 `json:"limit,omitempty"`

--- a/api/kbcloud/model_storage_class_list.go
+++ b/api/kbcloud/model_storage_class_list.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 // StorageClassList StorageClassList stands for stats for storage classes.
 type StorageClassList struct {

--- a/api/kbcloud/model_storage_list.go
+++ b/api/kbcloud/model_storage_list.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type StorageList struct {
+	Items []Storage
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewStorageList instantiates a new StorageList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewStorageList() *StorageList {
+	this := StorageList{}
+	return &this
+}
+
+// NewStorageListWithDefaults instantiates a new StorageList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewStorageListWithDefaults() *StorageList {
+	this := StorageList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o StorageList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *StorageList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_string_list.go
+++ b/api/kbcloud/model_string_list.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// StringList Represents a list of strings.
+type StringList struct {
+	Items []string
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewStringList instantiates a new StringList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewStringList() *StringList {
+	this := StringList{}
+	return &this
+}
+
+// NewStringListWithDefaults instantiates a new StringList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewStringListWithDefaults() *StringList {
+	this := StringList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o StringList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *StringList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_tenant_list.go
+++ b/api/kbcloud/model_tenant_list.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+// TenantList result set of Tenant
+type TenantList struct {
+	Items []Tenant
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTenantList instantiates a new TenantList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTenantList() *TenantList {
+	this := TenantList{}
+	return &this
+}
+
+// NewTenantListWithDefaults instantiates a new TenantList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTenantListWithDefaults() *TenantList {
+	this := TenantList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TenantList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TenantList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_tls_cert_list.go
+++ b/api/kbcloud/model_tls_cert_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type TlsCertList struct {
+	Items []TlsCert
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTlsCertList instantiates a new TlsCertList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTlsCertList() *TlsCertList {
+	this := TlsCertList{}
+	return &this
+}
+
+// NewTlsCertListWithDefaults instantiates a new TlsCertList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTlsCertListWithDefaults() *TlsCertList {
+	this := TlsCertList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TlsCertList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TlsCertList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_topic_broker_list.go
+++ b/api/kbcloud/model_topic_broker_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type TopicBrokerList struct {
+	Items []Broker
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTopicBrokerList instantiates a new TopicBrokerList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTopicBrokerList() *TopicBrokerList {
+	this := TopicBrokerList{}
+	return &this
+}
+
+// NewTopicBrokerListWithDefaults instantiates a new TopicBrokerList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTopicBrokerListWithDefaults() *TopicBrokerList {
+	this := TopicBrokerList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TopicBrokerList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TopicBrokerList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_topic_message_list.go
+++ b/api/kbcloud/model_topic_message_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type TopicMessageList struct {
+	Items []TopicMessage
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTopicMessageList instantiates a new TopicMessageList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTopicMessageList() *TopicMessageList {
+	this := TopicMessageList{}
+	return &this
+}
+
+// NewTopicMessageListWithDefaults instantiates a new TopicMessageList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTopicMessageListWithDefaults() *TopicMessageList {
+	this := TopicMessageList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TopicMessageList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TopicMessageList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_topic_offset.go
+++ b/api/kbcloud/model_topic_offset.go
@@ -4,7 +4,9 @@
 
 package kbcloud
 
-import "github.com/apecloud/kb-cloud-client-go/api/common"
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
 
 type TopicOffset struct {
 	// 主题名称

--- a/api/kbcloud/model_topic_offset_list.go
+++ b/api/kbcloud/model_topic_offset_list.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import (
+	"github.com/apecloud/kb-cloud-client-go/api/common"
+)
+
+type TopicOffsetList struct {
+	Items []TopicOffset
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTopicOffsetList instantiates a new TopicOffsetList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTopicOffsetList() *TopicOffsetList {
+	this := TopicOffsetList{}
+	return &this
+}
+
+// NewTopicOffsetListWithDefaults instantiates a new TopicOffsetList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTopicOffsetListWithDefaults() *TopicOffsetList {
+	this := TopicOffsetList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TopicOffsetList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TopicOffsetList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}

--- a/api/kbcloud/model_topics_list.go
+++ b/api/kbcloud/model_topics_list.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at ApeCloud (https://www.apecloud.com/).
+// Copyright 2022-Present ApeCloud Co., Ltd
+
+package kbcloud
+
+import "github.com/apecloud/kb-cloud-client-go/api/common"
+
+type TopicsList struct {
+	Items []Topic
+
+	// UnparsedObject contains the raw value of the array if there was an error when deserializing into the struct
+	UnparsedObject []interface{} `json:"-"`
+}
+
+// NewTopicsList instantiates a new TopicsList object.
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed.
+func NewTopicsList() *TopicsList {
+	this := TopicsList{}
+	return &this
+}
+
+// NewTopicsListWithDefaults instantiates a new TopicsList object.
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set.
+func NewTopicsListWithDefaults() *TopicsList {
+	this := TopicsList{}
+	return &this
+}
+
+// MarshalJSON serializes the struct using spec logic.
+func (o TopicsList) MarshalJSON() ([]byte, error) {
+	toSerialize := make([]interface{}, len(o.Items))
+	if o.UnparsedObject != nil {
+		return common.Marshal(o.UnparsedObject)
+	}
+	for i, item := range o.Items {
+		toSerialize[i] = item
+	}
+	return common.Marshal(toSerialize)
+}
+
+// UnmarshalJSON deserializes the given payload.
+func (o *TopicsList) UnmarshalJSON(bytes []byte) (err error) {
+	if err = common.Unmarshal(bytes, &o.Items); err != nil {
+		return err
+	}
+
+	if o.Items != nil && len(o.Items) > 0 {
+		for _, v := range o.Items {
+			if v.UnparsedObject != nil {
+				return common.Unmarshal(bytes, &o.UnparsedObject)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
```bash
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/model_import_number_field.go:22:10: too many errors
# github.com/apecloud/kb-cloud-client-go/api/kbcloud/admin
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_engine_definition_version_query.go:9:9: undefined: common
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_engine_definition_version_query.go:10:9: undefined: common
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_engine_definition_version_query.go:11:9: undefined: common
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_engine_definition_version_query.go:12:9: undefined: common
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_engine_definition_version_query.go:13:9: undefined: common
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_import_string_field.go:24:10: undefined: ImportFieldType
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_import_string_field.go:27:14: undefined: ImportStringValidation
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_import_integer_field.go:24:10: undefined: ImportFieldType
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_import_integer_field.go:27:14: undefined: ImportNumericValidation
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_import_number_field.go:22:10: undefined: ImportFieldType
/Users/heng4fun/go/pkg/mod/github.com/apecloud/kb-cloud-client-go@v1.0.3-0.20250919073211-a923a1703de9/api/kbcloud/admin/model_import_number_field.go:22:10: too many errors
```

### 主要修改
- 修复如果嵌套 ref 的 schema 有 nullable: true，生成的代码没有 import common 包的问题
- 修复有 allOf 引用 schema，额外新增字段，生成的代码没有 import 依赖包的问题
- 重新生成 go client

### 测试
本地 e2e replace 测试成功

<img width="2058" height="1656" alt="image" src="https://github.com/user-attachments/assets/6a18df52-8f03-4ec4-9d0e-650e65c49d0a" />
