### PR TITLE
feat(generator): support multi-field multipart request bodies

### DIFF
--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -336,15 +336,44 @@ def parameters(operation):
 
 
 def form_parameter(operation):
+    """Return the single binary file part of a multipart/form-data request body, if any.
+
+    Multi-field multipart bodies are supported: this function returns only the
+    binary (file upload) field, while non-binary text fields are emitted by
+    ``parameters()`` as ``in: "form"`` entries and rendered into
+    ``localVarFormParams`` by the api.j2 template.
+
+    Design constraint: at most one binary field is supported per operation
+    (single file upload). If a schema declares multiple binary fields, raise
+    ValueError to avoid silently dropping uploads. Lift this restriction only
+    when the runtime client wrapper grows multi-file support.
+    """
     if "requestBody" in operation and "multipart/form-data" in operation["requestBody"]["content"]:
         parent = operation["requestBody"]["content"]["multipart/form-data"]["schema"]
-        [(name, schema)] = list(parent["properties"].items())
+        binary_fields = [
+            (name, schema)
+            for name, schema in parent.get("properties", {}).items()
+            if schema.get("format") == "binary"
+        ]
+        if len(binary_fields) > 1:
+            op_id = operation.get("operationId", "<unknown>")
+            field_names = ", ".join(name for name, _ in binary_fields)
+            raise ValueError(
+                f"Operation {op_id}: multipart schema declares multiple binary "
+                f"fields ({field_names}); only single-file upload is currently "
+                f"supported. Update the runtime client wrapper before adding "
+                f"multi-file operations."
+            )
+        if not binary_fields:
+            return None
+        name, schema = binary_fields[0]
         return {
             "schema": schema,
             "name": name,
             "description": schema.get("description"),
             "required": name in parent.get("required", []),
         }
+    return None
 
 
 def need_body_parameter(operation):

--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -222,21 +222,44 @@ localVarQueryParams.Add("{{ parameter.name }}", {{ common_package_name }}.Parame
 	{%- endif %}
 	{%- endfor %}
 
-	{%- if formParameter %}
-    formFile := {{ common_package_name }}.FormFile{}
-	formFile.FormFileName = "{{ formParameter.name }}"
-	{%- if formParameter.required %}
-	localVarFile := {{ formParameter.name|variable_name}}
+	{#- Multi-field multipart: emit non-binary form fields into localVarFormParams.
+	   The single binary field (if any) is handled by the formParameter block below.
+	   Single-file multipart bodies have no non-binary fields, so this loop is a
+	   no-op in that case (preserves DmsImport / vulnUpload behavior). #}
+	{%- for name, parameter in operation|parameters if parameter.in == "form" and (parameter.schema.format is not defined or parameter.schema.format != "binary") %}
+	{%- if parameter.required %}
+	localVarFormParams.Set("{{ parameter.name }}", {{ common_package_name }}.ParameterToString({{ name|variable_name }}, ""))
 	{%- else %}
-	var localVarFile {{ get_type_for_parameter(formParameter) }}
-	if optionalParams.{{ formParameter.name|attribute_name }} != nil {
-		localVarFile = *optionalParams.{{ formParameter.name|attribute_name }}
+	if optionalParams.{{ name|attribute_name }} != nil {
+		localVarFormParams.Set("{{ parameter.name }}", {{ common_package_name }}.ParameterToString(*optionalParams.{{ name|attribute_name }}, ""))
 	}
 	{%- endif %}
+	{%- endfor %}
+
+	{%- if formParameter %}
+	{#- Required binary: always pass FormFile pointer (preserves original behavior).
+	   Optional binary: only construct and pass FormFile when caller provided a
+	   reader — passing &formFile with empty bytes would cause PrepareRequest to
+	   emit an empty multipart file part. #}
+	var localVarFormFile *{{ common_package_name }}.FormFile
+	{%- if formParameter.required %}
+	formFile := {{ common_package_name }}.FormFile{}
+	formFile.FormFileName = "{{ formParameter.name }}"
+	localVarFile := {{ formParameter.name|variable_name}}
 	if localVarFile != nil {
 		fbs, _ := _io.ReadAll(localVarFile)
 		formFile.FileBytes = fbs
 	}
+	localVarFormFile = &formFile
+	{%- else %}
+	if optionalParams.{{ formParameter.name|attribute_name }} != nil {
+		formFile := {{ common_package_name }}.FormFile{}
+		formFile.FormFileName = "{{ formParameter.name }}"
+		fbs, _ := _io.ReadAll(*optionalParams.{{ formParameter.name|attribute_name }})
+		formFile.FileBytes = fbs
+		localVarFormFile = &formFile
+	}
+	{%- endif %}
     {% if needBodyParameter %}
     localVarFormParams, err = {{ common_package_name }}.BuildFormParams({{ operation.get("x-codegen-request-body-name", "body")|variable_name }})
 	if err != nil {
@@ -273,7 +296,7 @@ localVarQueryParams.Add("{{ parameter.name }}", {{ common_package_name }}.Parame
 	{%- endfor %}
 	)
 	{%- endif %}
-	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, {% if formParameter %}&formFile{% else %}nil{% endif %})
+	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, {% if formParameter %}localVarFormFile{% else %}nil{% endif %})
 	if err != nil {
 		return {% if returnType %}localVarReturnValue, {% endif %}nil, err
 	}

--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -261,10 +261,26 @@ localVarQueryParams.Add("{{ parameter.name }}", {{ common_package_name }}.Parame
 	}
 	{%- endif %}
     {% if needBodyParameter %}
+	{%- if formParameter.required %}
     localVarFormParams, err = {{ common_package_name }}.BuildFormParams({{ operation.get("x-codegen-request-body-name", "body")|variable_name }})
 	if err != nil {
 		return {% if returnType %}localVarReturnValue, {% endif %}nil, {{ common_package_name }}.ReportError("Failed to build form params: %s", err.Error())
 	}
+	{%- else %}
+	{#- Mixed JSON+multipart with optional binary: when caller did not provide
+	   the file, send the body as JSON (localVarPostBody). When the file is
+	   provided, build multipart form params from the body so they ride
+	   alongside the file. The two paths are mutually exclusive — client.go
+	   PrepareRequest rejects setting both postBody and multipart form. #}
+	if localVarFormFile == nil {
+		localVarPostBody = &{{ operation.get("x-codegen-request-body-name", "body")|variable_name }}
+	} else {
+		localVarFormParams, err = {{ common_package_name }}.BuildFormParams({{ operation.get("x-codegen-request-body-name", "body")|variable_name }})
+		if err != nil {
+			return {% if returnType %}localVarReturnValue, {% endif %}nil, {{ common_package_name }}.ReportError("Failed to build form params: %s", err.Error())
+		}
+	}
+	{%- endif %}
 	{%- endif %}
 	{%- endif %}
 

--- a/api/kbcloud/admin/api_dms.go
+++ b/api/kbcloud/admin/api_dms.go
@@ -151,6 +151,7 @@ func (a *DmsApi) DataImport(ctx _context.Context, orgName string, clusterName st
 	localVarHeaderParams["Content-Type"] = "application/json"
 	localVarHeaderParams["Accept"] = "application/json"
 
+	var localVarFormFile *common.FormFile
 	formFile := common.FormFile{}
 	formFile.FormFileName = "file"
 	localVarFile := file
@@ -158,6 +159,7 @@ func (a *DmsApi) DataImport(ctx _context.Context, orgName string, clusterName st
 		fbs, _ := _io.ReadAll(localVarFile)
 		formFile.FileBytes = fbs
 	}
+	localVarFormFile = &formFile
 
 	localVarFormParams, err = common.BuildFormParams(body)
 	if err != nil {
@@ -168,7 +170,7 @@ func (a *DmsApi) DataImport(ctx _context.Context, orgName string, clusterName st
 		&localVarHeaderParams,
 		[2]string{"BearerToken", "authorization"},
 	)
-	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, &formFile)
+	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFile)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}

--- a/api/kbcloud/admin/api_enable_service_version.go
+++ b/api/kbcloud/admin/api_enable_service_version.go
@@ -76,27 +76,29 @@ func (a *EnableServiceVersionApi) EnableServiceVersion(ctx _context.Context, env
 	localVarHeaderParams["Content-Type"] = "application/json"
 	localVarHeaderParams["Accept"] = "application/json"
 
-	formFile := common.FormFile{}
-	formFile.FormFileName = "image"
-	var localVarFile _io.Reader
+	var localVarFormFile *common.FormFile
 	if optionalParams.Image != nil {
-		localVarFile = *optionalParams.Image
-	}
-	if localVarFile != nil {
-		fbs, _ := _io.ReadAll(localVarFile)
+		formFile := common.FormFile{}
+		formFile.FormFileName = "image"
+		fbs, _ := _io.ReadAll(*optionalParams.Image)
 		formFile.FileBytes = fbs
+		localVarFormFile = &formFile
 	}
 
-	localVarFormParams, err = common.BuildFormParams(body)
-	if err != nil {
-		return localVarReturnValue, nil, common.ReportError("Failed to build form params: %s", err.Error())
+	if localVarFormFile == nil {
+		localVarPostBody = &body
+	} else {
+		localVarFormParams, err = common.BuildFormParams(body)
+		if err != nil {
+			return localVarReturnValue, nil, common.ReportError("Failed to build form params: %s", err.Error())
+		}
 	}
 	common.SetAuthKeys(
 		ctx,
 		&localVarHeaderParams,
 		[2]string{"BearerToken", "authorization"},
 	)
-	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, &formFile)
+	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFile)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}

--- a/api/kbcloud/admin/api_vuln.go
+++ b/api/kbcloud/admin/api_vuln.go
@@ -300,6 +300,7 @@ func (a *VulnApi) UploadVulns(ctx _context.Context, file _io.Reader) (*_nethttp.
 	localVarHeaderParams["Content-Type"] = "multipart/form-data"
 	localVarHeaderParams["Accept"] = "application/json"
 
+	var localVarFormFile *common.FormFile
 	formFile := common.FormFile{}
 	formFile.FormFileName = "file"
 	localVarFile := file
@@ -307,13 +308,14 @@ func (a *VulnApi) UploadVulns(ctx _context.Context, file _io.Reader) (*_nethttp.
 		fbs, _ := _io.ReadAll(localVarFile)
 		formFile.FileBytes = fbs
 	}
+	localVarFormFile = &formFile
 
 	common.SetAuthKeys(
 		ctx,
 		&localVarHeaderParams,
 		[2]string{"BearerToken", "authorization"},
 	)
-	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, &formFile)
+	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFile)
 	if err != nil {
 		return nil, err
 	}

--- a/api/kbcloud/api_dms.go
+++ b/api/kbcloud/api_dms.go
@@ -151,6 +151,7 @@ func (a *DmsApi) DataImport(ctx _context.Context, orgName string, clusterName st
 	localVarHeaderParams["Content-Type"] = "application/json"
 	localVarHeaderParams["Accept"] = "application/json"
 
+	var localVarFormFile *common.FormFile
 	formFile := common.FormFile{}
 	formFile.FormFileName = "file"
 	localVarFile := file
@@ -158,6 +159,7 @@ func (a *DmsApi) DataImport(ctx _context.Context, orgName string, clusterName st
 		fbs, _ := _io.ReadAll(localVarFile)
 		formFile.FileBytes = fbs
 	}
+	localVarFormFile = &formFile
 
 	localVarFormParams, err = common.BuildFormParams(body)
 	if err != nil {
@@ -168,7 +170,7 @@ func (a *DmsApi) DataImport(ctx _context.Context, orgName string, clusterName st
 		&localVarHeaderParams,
 		[2]string{"BearerToken", "authorization"},
 	)
-	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, &formFile)
+	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFile)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}

--- a/api/kbcloud/api_enable_service_version.go
+++ b/api/kbcloud/api_enable_service_version.go
@@ -76,27 +76,29 @@ func (a *EnableServiceVersionApi) EnableServiceVersion(ctx _context.Context, env
 	localVarHeaderParams["Content-Type"] = "application/json"
 	localVarHeaderParams["Accept"] = "application/json"
 
-	formFile := common.FormFile{}
-	formFile.FormFileName = "image"
-	var localVarFile _io.Reader
+	var localVarFormFile *common.FormFile
 	if optionalParams.Image != nil {
-		localVarFile = *optionalParams.Image
-	}
-	if localVarFile != nil {
-		fbs, _ := _io.ReadAll(localVarFile)
+		formFile := common.FormFile{}
+		formFile.FormFileName = "image"
+		fbs, _ := _io.ReadAll(*optionalParams.Image)
 		formFile.FileBytes = fbs
+		localVarFormFile = &formFile
 	}
 
-	localVarFormParams, err = common.BuildFormParams(body)
-	if err != nil {
-		return localVarReturnValue, nil, common.ReportError("Failed to build form params: %s", err.Error())
+	if localVarFormFile == nil {
+		localVarPostBody = &body
+	} else {
+		localVarFormParams, err = common.BuildFormParams(body)
+		if err != nil {
+			return localVarReturnValue, nil, common.ReportError("Failed to build form params: %s", err.Error())
+		}
 	}
 	common.SetAuthKeys(
 		ctx,
 		&localVarHeaderParams,
 		[2]string{"BearerToken", "authorization"},
 	)
-	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, &formFile)
+	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFile)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}


### PR DESCRIPTION
支持 OpenAPI multipart/form-data 含多个非 binary 字段的请求体，并重新生成受影响的 API 代码，确保 checked-in client API 已由本 PR 的新 generator 产出。

PR 内含 3 个 commit（按 review iteration 顺序排列）：
1. `fa2f069`：支持 multi-field multipart request body。
2. `b8d4c34`：修复 mixed JSON + multipart 且 optional binary 缺省时 body 为空的问题。
3. `5c8c35a`：用新 generator 重新生成 API 代码。

## 问题现象

`apecloud/apecloud#17592` 把 `createEngineLicense` 的 multipart/form-data 请求体从匿名单字段 schema 升级为 `$ref` 到 `engineLicenseCreate`，包含多个普通字段和一个 `licenseFile` 字段。旧 generator 在生成 Go client 时会报错：

```text
.generator/src/generator/openapi.py:341
ValueError: too many values to unpack (expected 1)
```

后续 review 又发现两个兼容问题：

- optional binary 缺省时会构造空 `FormFile`，导致请求多一个空 file part。
- `EnableServiceVersion` 这类 mixed JSON + multipart + optional binary 接口，在不传文件时没有把 JSON body 传给 `PrepareRequest`，请求 body 会变空。

## 根因

1. `openapi.py:form_parameter` 假设 multipart schema 只有一个属性，不能处理多个普通字段加一个 binary 字段的 schema。
2. `templates/api.j2` 对 required / optional binary 都无条件传 `&formFile`，而 `PrepareRequest` 只要看到非 nil `formFile` 就会发 file part。
3. mixed JSON + multipart + optional binary 没有按运行时是否传文件做分流：无文件时应该走 JSON body，有文件时才走 multipart。

## 修复范围

- `openapi.py:form_parameter` 改为只挑 `format: binary` 字段；多个 binary 字段直接 fail-fast；无 binary 字段返回 None。
- `templates/api.j2` 支持把 multipart schema 里的非 binary 字段展开到 `localVarFormParams`。
- optional binary 改为 pointer-based `localVarFormFile`：调用方没传文件时保持 nil，不再发空文件。
- mixed JSON + multipart + optional binary 增加运行时分流：
  - 无文件：`localVarPostBody = &body`，走 JSON body。
  - 有文件：`BuildFormParams(body)` + `localVarFormFile`，走 multipart。
- 用新 generator 重新生成了受影响的 API 文件：
  - `api/kbcloud/api_enable_service_version.go`
  - `api/kbcloud/admin/api_enable_service_version.go`
  - `api/kbcloud/api_dms.go`
  - `api/kbcloud/admin/api_dms.go`
  - `api/kbcloud/admin/api_vuln.go`

## 验证命令

生成命令（本机没有 poetry / Python 3.10，使用临时 venv 直接安装 generator 依赖）：

```bash
cd .generator
PYTHONPATH=src python -m generator ./schemas/* -o ../api
goimports -w ../api
```

本地验证：

```bash
git diff --check
go test ./api/common ./api/kbcloud
```

结果：通过。

额外说明：

- `go test ./...` 目前会在 `api/kbcloud/admin` 的既有 enum 生成物上失败，失败文件包括 `model_cluster_scheduling_policy.go` 和 `model_target_role.go`。这两个文件不在本 PR diff 中，重新生成前后内容一致，不是本次改动引入。
- `tests` 模块的 API 测试依赖运行环境配置，本地无目标环境时会报 `index 0 out of range -1`。

## 是否需要 pick-2.2

该 PR 是 generator 仓修复，自身不需要 cherry-pick。下游 `apecloud/apecloud#17592` 需要等本 PR 合入或同步到对应 client-go 分支后再重新跑 `check-client-go`。