### PR TITLE
fix: generate engineLicense multipart client

### DIFF
--- a/api/kbcloud/admin/api_engine_license.go
+++ b/api/kbcloud/admin/api_engine_license.go
@@ -7,8 +7,10 @@ package admin
 import (
 	"context"
 	_context "context"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
+	"time"
 
 	"github.com/apecloud/kb-cloud-client-go/api/common"
 )
@@ -16,14 +18,60 @@ import (
 // EngineLicenseApi service type
 type EngineLicenseApi common.Service
 
+// CreateEngineLicenseOptionalParameters holds optional parameters for CreateEngineLicense.
+type CreateEngineLicenseOptionalParameters struct {
+	Description   *string
+	ExpiredAt     *time.Time
+	EnvironmentId *string
+	LicenseFile   *_io.Reader
+}
+
+// NewCreateEngineLicenseOptionalParameters creates an empty struct for parameters.
+func NewCreateEngineLicenseOptionalParameters() *CreateEngineLicenseOptionalParameters {
+	this := CreateEngineLicenseOptionalParameters{}
+	return &this
+}
+
+// WithDescription sets the corresponding parameter name and returns the struct.
+func (r *CreateEngineLicenseOptionalParameters) WithDescription(description string) *CreateEngineLicenseOptionalParameters {
+	r.Description = &description
+	return r
+}
+
+// WithExpiredAt sets the corresponding parameter name and returns the struct.
+func (r *CreateEngineLicenseOptionalParameters) WithExpiredAt(expiredAt time.Time) *CreateEngineLicenseOptionalParameters {
+	r.ExpiredAt = &expiredAt
+	return r
+}
+
+// WithEnvironmentId sets the corresponding parameter name and returns the struct.
+func (r *CreateEngineLicenseOptionalParameters) WithEnvironmentId(environmentId string) *CreateEngineLicenseOptionalParameters {
+	r.EnvironmentId = &environmentId
+	return r
+}
+
+// WithLicenseFile sets the corresponding parameter name and returns the struct.
+func (r *CreateEngineLicenseOptionalParameters) WithLicenseFile(licenseFile _io.Reader) *CreateEngineLicenseOptionalParameters {
+	r.LicenseFile = &licenseFile
+	return r
+}
+
 // CreateEngineLicense Create engineLicense.
 // Create a new engineLicense
-func (a *EngineLicenseApi) CreateEngineLicense(ctx _context.Context, body EngineLicenseCreate) (EngineLicense, *_nethttp.Response, error) {
+func (a *EngineLicenseApi) CreateEngineLicense(ctx _context.Context, name string, engineName string, typeVar string, o ...CreateEngineLicenseOptionalParameters) (EngineLicense, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod  = _nethttp.MethodPost
 		localVarPostBody    interface{}
 		localVarReturnValue EngineLicense
+		optionalParams      CreateEngineLicenseOptionalParameters
 	)
+
+	if len(o) > 1 {
+		return localVarReturnValue, nil, common.ReportError("only one argument of type CreateEngineLicenseOptionalParameters is allowed")
+	}
+	if len(o) == 1 {
+		optionalParams = o[0]
+	}
 
 	// Add api info to context
 	apiInfo := common.APIInfo{
@@ -44,17 +92,36 @@ func (a *EngineLicenseApi) CreateEngineLicense(ctx _context.Context, body Engine
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
-	localVarHeaderParams["Content-Type"] = "application/json"
+	localVarHeaderParams["Content-Type"] = "multipart/form-data"
 	localVarHeaderParams["Accept"] = "application/json"
 
-	// body params
-	localVarPostBody = &body
+	localVarFormParams.Set("name", common.ParameterToString(name, ""))
+	localVarFormParams.Set("engineName", common.ParameterToString(engineName, ""))
+	if optionalParams.Description != nil {
+		localVarFormParams.Set("description", common.ParameterToString(*optionalParams.Description, ""))
+	}
+	if optionalParams.ExpiredAt != nil {
+		localVarFormParams.Set("expiredAt", common.ParameterToString(*optionalParams.ExpiredAt, ""))
+	}
+	if optionalParams.EnvironmentId != nil {
+		localVarFormParams.Set("environmentID", common.ParameterToString(*optionalParams.EnvironmentId, ""))
+	}
+	localVarFormParams.Set("type", common.ParameterToString(typeVar, ""))
+	var localVarFormFile *common.FormFile
+	if optionalParams.LicenseFile != nil {
+		formFile := common.FormFile{}
+		formFile.FormFileName = "licenseFile"
+		fbs, _ := _io.ReadAll(*optionalParams.LicenseFile)
+		formFile.FileBytes = fbs
+		localVarFormFile = &formFile
+	}
+
 	common.SetAuthKeys(
 		ctx,
 		&localVarHeaderParams,
 		[2]string{"BearerToken", "authorization"},
 	)
-	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, nil)
+	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFile)
 	if err != nil {
 		return localVarReturnValue, nil, err
 	}

--- a/api/kbcloud/admin/model_cluster_scheduling_policy.go
+++ b/api/kbcloud/admin/model_cluster_scheduling_policy.go
@@ -21,14 +21,14 @@ const (
 	ClusterSchedulingPolicyHardAntiAffinity ClusterSchedulingPolicy = "HardAntiAffinity"
 	ClusterSchedulingPolicySoftAntiAffinity ClusterSchedulingPolicy = "SoftAntiAffinity"
 	ClusterSchedulingPolicyDisabled         ClusterSchedulingPolicy = "Disabled"
-	ClusterSchedulingPolicy                 ClusterSchedulingPolicy = "None"
+	ClusterSchedulingPolicyNone             ClusterSchedulingPolicy = "None"
 )
 
 var allowedClusterSchedulingPolicyEnumValues = []ClusterSchedulingPolicy{
 	ClusterSchedulingPolicyHardAntiAffinity,
 	ClusterSchedulingPolicySoftAntiAffinity,
 	ClusterSchedulingPolicyDisabled,
-	ClusterSchedulingPolicy,
+	ClusterSchedulingPolicyNone,
 }
 
 // GetAllowedValues returns the list of possible values.

--- a/api/kbcloud/admin/model_target.go
+++ b/api/kbcloud/admin/model_target.go
@@ -27,7 +27,7 @@ func NewTarget() *Target {
 	this := Target{}
 	var component string = "*"
 	this.Component = &component
-	var role Target_role = Target_role
+	var role Target_role = Target_roleWildcard
 	this.Role = &role
 	return &this
 }
@@ -39,7 +39,7 @@ func NewTargetWithDefaults() *Target {
 	this := Target{}
 	var component string = "*"
 	this.Component = &component
-	var role Target_role = Target_role
+	var role Target_role = Target_roleWildcard
 	this.Role = &role
 	return &this
 }

--- a/api/kbcloud/admin/model_target_role.go
+++ b/api/kbcloud/admin/model_target_role.go
@@ -15,13 +15,13 @@ type Target_role string
 
 // List of Target_role.
 const (
-	Target_rolePrimary Target_role = "Primary"
-	Target_role        Target_role = "*"
+	Target_rolePrimary  Target_role = "Primary"
+	Target_roleWildcard Target_role = "*"
 )
 
 var allowedTarget_roleEnumValues = []Target_role{
 	Target_rolePrimary,
-	Target_role,
+	Target_roleWildcard,
 }
 
 // GetAllowedValues returns the list of possible values.


### PR DESCRIPTION
## 问题现象

apecloud/apecloud 的 E2E 规则要求测试通过 `kb-cloud-client-go` 调 API，不再手写 HTTP 请求。engineLicense 创建接口在 apecloud/apecloud PR #17592 后已经改为 `multipart/form-data`，但 `kb-cloud-client-go` main 上的 generated client 仍然按 JSON body 发送，导致 apecloud E2E PR #17714 无法改回 generated client。

关联：apecloud/apecloud issue #11922、apecloud/apecloud PR #17714。

## 根因

`kb-cloud-client-go` main 已包含 multipart generator 支持，但 engineLicense 的 generated artifact 尚未合入 main：

- 旧签名：`CreateEngineLicense(ctx, body EngineLicenseCreate)`
- 旧请求：`Content-Type: application/json`

另外，当前 main 的两个 generated enum 常量名与类型名冲突，导致更新依赖后 `go test ./...` 不能通过。

## 修复范围

- 更新 `api/kbcloud/admin/api_engine_license.go`，生成 multipart 版本的 `CreateEngineLicense`：
  - 必填 form fields：`name`、`engineName`、`type`
  - 可选 fields：`description`、`expiredAt`、`environmentID`、`licenseFile`
  - 请求头改为 `multipart/form-data`
- 修正两个 generated enum 命名冲突，使当前 client-go main 可以被下游 Go 测试正常编译消费：
  - `ClusterSchedulingPolicyNone`
  - `Target_roleWildcard`

## 验证命令

```bash
go test ./api/kbcloud/admin -run '^$'
go test ./...
git diff --check HEAD~1..HEAD
```

## 后续

本 PR 合入后，apecloud/apecloud 的 E2E 可以更新 `github.com/apecloud/kb-cloud-client-go` 依赖到新的 main pseudo-version，并把 engineLicense 测试改回 generated client 调用，不再使用手写 multipart HTTP。
