### PR TITLE
fix(generator): sanitize bundled schema names

### DIFF
--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -26,7 +26,7 @@ def get_name(schema):
     name = None
     if hasattr(schema, "__reference__"):
         name = schema.__reference__["$ref"].split("/")[-1]
-        name = utils.upperfirst(name)
+        name = utils.go_type_name(name)
 
     return name
 
@@ -279,9 +279,11 @@ def models(spec):
     if "components" in spec and "schemas" in spec["components"]:
         for schema_name, schema_def in spec["components"]["schemas"].items():
             # Add the schema itself
-            name_to_schema[schema_name] = schema_def
+            name_to_schema[get_name(schema_def) or utils.go_type_name(schema_name)] = schema_def
             # Also collect any child models from this schema
-            name_to_schema.update(dict(child_models(schema_def, alternative_name=schema_name)))
+            name_to_schema.update(
+                dict(child_models(schema_def, alternative_name=get_name(schema_def) or utils.go_type_name(schema_name)))
+            )
 
     return name_to_schema
 

--- a/.generator/src/generator/utils.py
+++ b/.generator/src/generator/utils.py
@@ -5,6 +5,7 @@ PATTERN_DOUBLE_UNDERSCORE = re.compile(r"__+")
 PATTERN_LEADING_ALPHA = re.compile(r"(.)([A-Z][a-z]+)")
 PATTERN_FOLLOWING_ALPHA = re.compile(r"([a-z0-9])([A-Z])")
 PATTERN_WHITESPACE = re.compile(r"\W")
+PATTERN_GO_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # Other client generators have more edge cases defined but adding them here could cause backwards-incompatible breaking changes.
 EDGE_CASES = {"APIs": "Apis"}
 
@@ -31,6 +32,21 @@ def upperfirst(value):
     return value[0].upper() + value[1:]
 
 
+def go_type_name(value):
+    """Return a Go type identifier for an OpenAPI schema name."""
+    if value is None:
+        return None
+    if PATTERN_GO_IDENTIFIER.match(value):
+        return upperfirst(value)
+
+    name = camel_case(value)
+    if not name:
+        return name
+    if name[0].isdigit():
+        name = "Model" + name
+    return name
+
+
 def camel_case(value):
     return "".join(upperfirst(x) for x in snake_case(value).split("_"))
 
@@ -44,7 +60,7 @@ def schema_name(schema):
         return None
 
     if hasattr(schema, "__reference__"):
-        return schema.__reference__["$ref"].split("/")[-1]
+        return go_type_name(schema.__reference__["$ref"].split("/")[-1])
 
 
 def given_variables(context):

--- a/.github/workflows/auto-update-client-api.yml
+++ b/.github/workflows/auto-update-client-api.yml
@@ -8,6 +8,8 @@ env:
   POETRY_VERSION: "1.7.1"
   PYTHON_VERSION: "3.11"
   GO_VERSION: "1.22"
+  NODE_VERSION: "20.19.0"
+  REDOCLY_CLI_VERSION: "2.30.4"
   APECLOUD_COMMIT_URL: "https://github.com/apecloud/apecloud/commit"
 
 jobs:
@@ -37,6 +39,11 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Checkout apecloud Code
         uses: actions/checkout@v4
         with:
@@ -48,7 +55,7 @@ jobs:
       - name: bundle openapi and adminapi
         run: |
           go install golang.org/x/tools/cmd/goimports@latest
-          npm install @redocly/cli -g
+          npm install @redocly/cli@${REDOCLY_CLI_VERSION} -g
           
           cd ./apecloud
           git fetch --prune --unshallow


### PR DESCRIPTION
## 问题

`Auto Update Client API` 使用当前最新 `@redocly/cli` bundle `apecloud` main 的 API yaml 时，会把重名但内容不同的 schema 自动重命名为 `initOptionItem-2`、`endpointType-2`、`eventList-2` 等。

现有 generator 直接使用 `$ref` 尾段作为 Go 类型名，导致生成如下非法 Go 代码：

- `type EndpointType-2 string`
- `[]InitOptionItem-2`

workflow 失败在 `goimports -w ../api`，典型错误是 `expected type, found '-'`。

另外，workflow 里原来使用 `npm install @redocly/cli -g`，没有固定 redocly 版本；本地和 CI 很容易因为 redocly 版本不同而得到不同 bundle 结果。

## 关于同名 schema

这次直接触发冲突的 schema 是：

- `cluster.yaml#/initOptionItem` 与 `engineOption.yaml#/initOptionItem`，结构不同。
- `cluster.yaml#/endpointType` 与 `dataReplication.yaml#/endpointType`，含义和枚举值不同。
- `cluster.yaml#/eventList` 与 `dataReplication.yaml#/eventList`，一个是操作事件分页对象，一个是数据复制事件数组。

这些同名 schema 在拆分文件里能读懂，但 bundle 到全局 OpenAPI components 后不理想；长期更好的做法是 API schema 侧改成领域化名字，例如 `ClusterInitOptionItem` / `EngineInitOptionItem` / `DataReplicationEndpointType`。不过 generator 也应该能处理 redocly 合法产出的 disambiguated 名字，不能生成非法 Go identifier。

## 修复

只改 generator / workflow，不手工修改 generated client-go artifact：

- 新增 `go_type_name()`，把 `$ref`/schema 名统一转换为合法 Go type identifier。
- `schema_name()` 和 `get_name()` 都走同一套转换。
- components schema 入口也使用转换后的名字，避免生成文件名和类型名继续带 `-`。
- pin workflow 的 Node / Redocly 版本：`NODE_VERSION=20.19.0`，`REDOCLY_CLI_VERSION=2.30.4`，避免本地/CI 使用不同 redocly 版本。

## 验证

使用最新 `apecloud` main API yaml 和最新 `kb-cloud-client-go` main 复现 CI 路径：

- `npx -y @redocly/cli@latest bundle ./api/openapi.yaml > ./openapi-bundle-tmp-latest.yaml`
- `npx -y @redocly/cli@latest bundle ./api/adminapi.yaml > ./adminapi-bundle-tmp-latest.yaml`
- `bash ./generate.sh`
- `go test ./api/kbcloud/admin -run '^$'`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

同时确认生成后的 engineLicense client 是 multipart 签名：

`CreateEngineLicense(ctx, name, engineName, typeVar, opts...)`，`Content-Type=multipart/form-data`，支持 optional `licenseFile`。
