### PR TITLE
chore: pin client API generation tool versions

### DIFF
--- a/.github/workflows/auto-update-client-api.yml
+++ b/.github/workflows/auto-update-client-api.yml
@@ -8,6 +8,8 @@ env:
   POETRY_VERSION: "1.7.1"
   PYTHON_VERSION: "3.11"
   GO_VERSION: "1.22"
+  NODE_VERSION: "20.19.0"
+  REDOCLY_CLI_VERSION: "2.30.4"
   APECLOUD_COMMIT_URL: "https://github.com/apecloud/apecloud/commit"
 
 jobs:
@@ -37,6 +39,11 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Checkout apecloud Code
         uses: actions/checkout@v4
         with:
@@ -48,7 +55,7 @@ jobs:
       - name: bundle openapi and adminapi
         run: |
           go install golang.org/x/tools/cmd/goimports@latest
-          npm install @redocly/cli -g
+          npm install @redocly/cli@${REDOCLY_CLI_VERSION} -g
           
           cd ./apecloud
           git fetch --prune --unshallow


### PR DESCRIPTION
## 背景

`Auto Update Client API` 负责用 `apecloud` API yaml 生成 `kb-cloud-client-go`。当前 workflow 使用 `npm install @redocly/cli -g`，会随 latest 版本变化，和 `apecloud` PR 侧 `check-client-go` 的 bundle 口径可能不一致。

这次 engineLicense E2E 链路里，问题正是被 latest Redocly bundle 暴露出来；为了避免本地、PR 检查和手动生成的结果不一致，需要固定生成工具版本。

## 修改范围

- 固定 Node 版本为 `20.19.0`
- 固定 Redocly CLI 版本为 `2.30.4`
- 不修改 generator 代码
- 不修改任何 generated artifact

## 验证

```bash
git diff --check
```

后续需要在 apecloud API schema 去重 PR 合入后，重新触发 `Auto Update Client API` 验证实际生成结果。
