### PR TITLE
fix: handle multipart schemas with metadata fields

### DIFF
--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -338,7 +338,12 @@ def parameters(operation):
 def form_parameter(operation):
     if "requestBody" in operation and "multipart/form-data" in operation["requestBody"]["content"]:
         parent = operation["requestBody"]["content"]["multipart/form-data"]["schema"]
-        [(name, schema)] = list(parent["properties"].items())
+        form_fields = [
+            (name, schema)
+            for name, schema in parent["properties"].items()
+            if schema.get("format") == "binary"
+        ]
+        [(name, schema)] = form_fields
         return {
             "schema": schema,
             "name": name,

--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -222,6 +222,19 @@ localVarQueryParams.Add("{{ parameter.name }}", {{ common_package_name }}.Parame
 	{%- endif %}
 	{%- endfor %}
 
+	{%- for name, parameter in operation|parameters if parameter.in == "form" and (not formParameter or name != formParameter.name) %}
+	{%- set collectionFormat = parameter|collection_format %}
+	{%- if parameter.required %}
+
+	localVarFormParams.Add("{{ parameter.name }}", {{ common_package_name }}.ParameterToString({{ name|variable_name}}, "{{collectionFormat}}"))
+	{%- else %}
+
+	if optionalParams.{{ name|attribute_name }} != nil {
+		localVarFormParams.Add("{{ parameter.name }}", {{ common_package_name }}.ParameterToString(*optionalParams.{{ name|attribute_name }}, "{{collectionFormat}}"))
+	}
+	{%- endif %}
+	{%- endfor %}
+
 	{%- if formParameter %}
     formFile := {{ common_package_name }}.FormFile{}
 	formFile.FormFileName = "{{ formParameter.name }}"


### PR DESCRIPTION
ref: https://github.com/apecloud/apecloud/actions/runs/25648734765/job/75297259297
这个 PR 修的是 `kb-cloud-client-go` generator 对 `multipart/form-data` 多字段请求的兼容问题。

## 问题

ApeCloud PR #17613 触发 `check-client-go` 时，会把当前 `openapi.yaml` 和 `adminapi.yaml` 全量交给 client-go generator 生成 SDK。

生成过程走到已有 admin API `engineLicenseCreate` 时失败：

    ValueError: too many values to unpack (expected 1)

原因是旧 generator 的 `form_parameter()` 假设每个 multipart schema 只有一个 property：

    [(name, schema)] = list(parent["properties"].items())

但 `engineLicenseCreate` 是一个合法的多字段 multipart 请求体：

- `licenseFile`：文件字段，`type: string`，`format: binary`
- `name`、`engineName`、`type`、`description`、`expiredAt`、`environmentID`：普通 multipart form 字段

所以这个失败不是 dataReplication check API schema 引入的。dataReplication PR 只是触发了全量 client-go 生成，从而暴露了 generator 里已有的 multipart 兼容性限制。

## 修复

这个 PR 让 generator 支持“文件字段 + 普通表单字段”的 multipart schema：

- 把 `format: binary` 的 property 识别为文件字段，用于 `FormFile`
- 把其它非文件字段继续生成到 `localVarFormParams`
- 不修改 ApeCloud OpenAPI schema，也不改变运行时 API 语义

以 `CreateEngineLicense` 为例，生成后的 SDK 会同时发送这些 multipart parts：

- `name`
- `engineName`
- `type`
- `description`
- `expiredAt`
- `environmentID`
- `licenseFile`

## 为什么不改 ApeCloud schema

如果为了绕过 CI，把 ApeCloud 的 `engineLicenseCreate` schema 临时改成只包含 `licenseFile`，OpenAPI 就会和真实 handler 不一致。

真实 handler 需要文件，也需要 `name/engineName/type/...` 这些 metadata form 字段。正确修复位置应该是 client-go generator，而不是扭曲 ApeCloud API schema。

## 验证

已用 ApeCloud PR #17613 当前 bundled `openapi.yaml` 和 `adminapi.yaml` 本地重新生成 client-go。

结果：原来的 `too many values to unpack` 不再复现，生成出的 `CreateEngineLicense` 仍然包含 metadata form fields 和 file part。
