### PR TITLE
fix: compile generated MongoDB client

### DIFF
--- a/api/kbcloud/api_dms.go
+++ b/api/kbcloud/api_dms.go
@@ -1019,7 +1019,7 @@ func (a *DmsApi) DropMongoCollection(ctx _context.Context, orgName string, clust
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := common.ReadBody(localVarHTTPResponse)
+	_, err = common.ReadBody(localVarHTTPResponse)
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -2156,7 +2156,7 @@ func (a *DmsApi) MongoCreateIndex(ctx _context.Context, orgName string, clusterN
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := common.ReadBody(localVarHTTPResponse)
+	_, err = common.ReadBody(localVarHTTPResponse)
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -2214,7 +2214,7 @@ func (a *DmsApi) MongoCreateView(ctx _context.Context, orgName string, clusterNa
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := common.ReadBody(localVarHTTPResponse)
+	_, err = common.ReadBody(localVarHTTPResponse)
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -2340,7 +2340,7 @@ func (a *DmsApi) MongoDropIndex(ctx _context.Context, orgName string, clusterNam
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := common.ReadBody(localVarHTTPResponse)
+	_, err = common.ReadBody(localVarHTTPResponse)
 	if err != nil {
 		return localVarHTTPResponse, err
 	}
@@ -2805,7 +2805,7 @@ func (a *DmsApi) MongoSetValidation(ctx _context.Context, orgName string, cluste
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := common.ReadBody(localVarHTTPResponse)
+	_, err = common.ReadBody(localVarHTTPResponse)
 	if err != nil {
 		return localVarHTTPResponse, err
 	}

--- a/api/kbcloud/model_ai_agent_action_branch_status.go
+++ b/api/kbcloud/model_ai_agent_action_branch_status.go
@@ -14,7 +14,7 @@ type AiAgentActionBranchStatus string
 
 // List of AiAgentActionBranchStatus.
 const (
-	AiAgentActionBranchStatus                    AiAgentActionBranchStatus = "none"
+	AiAgentActionBranchStatusNone                AiAgentActionBranchStatus = "none"
 	AiAgentActionBranchStatusPendingConfirmation AiAgentActionBranchStatus = "pending_confirmation"
 	AiAgentActionBranchStatusApproved            AiAgentActionBranchStatus = "approved"
 	AiAgentActionBranchStatusExecuting           AiAgentActionBranchStatus = "executing"
@@ -25,7 +25,7 @@ const (
 )
 
 var allowedAiAgentActionBranchStatusEnumValues = []AiAgentActionBranchStatus{
-	AiAgentActionBranchStatus,
+	AiAgentActionBranchStatusNone,
 	AiAgentActionBranchStatusPendingConfirmation,
 	AiAgentActionBranchStatusApproved,
 	AiAgentActionBranchStatusExecuting,

--- a/api/kbcloud/model_ai_agent_confidence.go
+++ b/api/kbcloud/model_ai_agent_confidence.go
@@ -17,14 +17,14 @@ const (
 	AiAgentConfidenceHigh   AiAgentConfidence = "high"
 	AiAgentConfidenceMedium AiAgentConfidence = "medium"
 	AiAgentConfidenceLow    AiAgentConfidence = "low"
-	AiAgentConfidence       AiAgentConfidence = "none"
+	AiAgentConfidenceNone   AiAgentConfidence = "none"
 )
 
 var allowedAiAgentConfidenceEnumValues = []AiAgentConfidence{
 	AiAgentConfidenceHigh,
 	AiAgentConfidenceMedium,
 	AiAgentConfidenceLow,
-	AiAgentConfidence,
+	AiAgentConfidenceNone,
 }
 
 // GetAllowedValues returns the list of possible values.

--- a/api/kbcloud/model_ai_agent_recover_action_type.go
+++ b/api/kbcloud/model_ai_agent_recover_action_type.go
@@ -21,7 +21,7 @@ const (
 	AiAgentRecoverActionTypeViewReport            AiAgentRecoverActionType = "view_report"
 	AiAgentRecoverActionTypeRegenerateReport      AiAgentRecoverActionType = "regenerate_report"
 	AiAgentRecoverActionTypeContinueInvestigation AiAgentRecoverActionType = "continue_investigation"
-	AiAgentRecoverActionType                      AiAgentRecoverActionType = "none"
+	AiAgentRecoverActionTypeNone                  AiAgentRecoverActionType = "none"
 )
 
 var allowedAiAgentRecoverActionTypeEnumValues = []AiAgentRecoverActionType{
@@ -32,7 +32,7 @@ var allowedAiAgentRecoverActionTypeEnumValues = []AiAgentRecoverActionType{
 	AiAgentRecoverActionTypeViewReport,
 	AiAgentRecoverActionTypeRegenerateReport,
 	AiAgentRecoverActionTypeContinueInvestigation,
-	AiAgentRecoverActionType,
+	AiAgentRecoverActionTypeNone,
 }
 
 // GetAllowedValues returns the list of possible values.

--- a/api/kbcloud/model_ai_agent_root_cause_type.go
+++ b/api/kbcloud/model_ai_agent_root_cause_type.go
@@ -16,13 +16,13 @@ type AiAgentRootCauseType string
 const (
 	AiAgentRootCauseTypeConfirmed AiAgentRootCauseType = "confirmed"
 	AiAgentRootCauseTypeCandidate AiAgentRootCauseType = "candidate"
-	AiAgentRootCauseType          AiAgentRootCauseType = "none"
+	AiAgentRootCauseTypeNone      AiAgentRootCauseType = "none"
 )
 
 var allowedAiAgentRootCauseTypeEnumValues = []AiAgentRootCauseType{
 	AiAgentRootCauseTypeConfirmed,
 	AiAgentRootCauseTypeCandidate,
-	AiAgentRootCauseType,
+	AiAgentRootCauseTypeNone,
 }
 
 // GetAllowedValues returns the list of possible values.


### PR DESCRIPTION
## 目标

修复最新 `kb-cloud-client-go` 生成代码在 Go 编译阶段的错误，使 apecloud E2E 可以升级到包含 MongoDB S1 datasource API 的最新 SDK，并通过 SDK 调用 apiserver API。

## 作用

- 解除 `api/kbcloud` 包的编译阻塞。
- 为 apecloud MongoDB S1 E2E 改造提供可用的 `kb-cloud-client-go` 依赖版本。
- 不调整 API 语义，不新增或删除接口。

## 实现方式 / 原理

- 将 AI Agent 枚举中 value 为 `none` 且生成后与类型名同名的常量改为 `*None` 后缀，避免 Go 标识符重名。
- 将 MongoDB DMS 无响应体接口里未使用的 `localVarBody` 改为 `_`，保留 `common.ReadBody` 对 response body 的重置行为。

## 验证结果

```bash
go test ./...
```

结果：通过。

## 边界

- 这是生成代码编译修复，不改变 MongoDB API 契约。
- 该 PR 是 apecloud MongoDB E2E SDK 化 PR 的依赖。
