### PR TITLE
fix: avoid enum none name collisions

### DIFF
--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -132,7 +132,7 @@ def get_enum_varname(schema, index):
         varname = "Empty"
     if varname == "*":
         varname = "All"
-    if varname == "None":
+    if varname.lower() == "none":
         varname = "Non"
     return camel_case(varname.replace("-", "_"))
 

--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -22,6 +22,7 @@ type {{ classname }} {{ common_package_name }}.Service
 {%- set returnType = operation|return_type %}
 {%- set formParameter = operation|form_parameter %}
 {%- set needBodyParameter = operation|need_body_parameter %}
+{%- set errorResponses = operation|responses_by_types|list %}
 {%- set operationId = operation.operationId|upperfirst %}
 
 {%- for name, parameter in operation|parameters if not parameter.required and parameter.in != "path" %}
@@ -321,14 +322,14 @@ localVarQueryParams.Add("{{ parameter.name }}", {{ common_package_name }}.Parame
 	if err != nil || localVarHTTPResponse == nil {
 		return {% if returnType %}localVarReturnValue, {% endif %}localVarHTTPResponse, err
 	}
-	{%- if returnType != '_io.Reader' %}
+	{%- if returnType != '_io.Reader' and (returnType or errorResponses) %}
 
 	localVarBody, err := common.ReadBody(localVarHTTPResponse)
 	if err != nil {
 		return {% if returnType %}localVarReturnValue, {% endif %}localVarHTTPResponse, err
 	}
 	{%- endif %}
-	{%- for responseType, (response, responseCodes) in operation|responses_by_types %}
+	{%- for responseType, (response, responseCodes) in errorResponses %}
 	{%- if loop.first %}
 
 	if localVarHTTPResponse.StatusCode >= 300 {

--- a/api/kbcloud/model_ai_agent_action_branch_status.go
+++ b/api/kbcloud/model_ai_agent_action_branch_status.go
@@ -14,7 +14,7 @@ type AiAgentActionBranchStatus string
 
 // List of AiAgentActionBranchStatus.
 const (
-	AiAgentActionBranchStatus                    AiAgentActionBranchStatus = "none"
+	AiAgentActionBranchStatusNon                 AiAgentActionBranchStatus = "none"
 	AiAgentActionBranchStatusPendingConfirmation AiAgentActionBranchStatus = "pending_confirmation"
 	AiAgentActionBranchStatusApproved            AiAgentActionBranchStatus = "approved"
 	AiAgentActionBranchStatusExecuting           AiAgentActionBranchStatus = "executing"
@@ -25,7 +25,7 @@ const (
 )
 
 var allowedAiAgentActionBranchStatusEnumValues = []AiAgentActionBranchStatus{
-	AiAgentActionBranchStatus,
+	AiAgentActionBranchStatusNon,
 	AiAgentActionBranchStatusPendingConfirmation,
 	AiAgentActionBranchStatusApproved,
 	AiAgentActionBranchStatusExecuting,

--- a/api/kbcloud/model_ai_agent_confidence.go
+++ b/api/kbcloud/model_ai_agent_confidence.go
@@ -17,14 +17,14 @@ const (
 	AiAgentConfidenceHigh   AiAgentConfidence = "high"
 	AiAgentConfidenceMedium AiAgentConfidence = "medium"
 	AiAgentConfidenceLow    AiAgentConfidence = "low"
-	AiAgentConfidence       AiAgentConfidence = "none"
+	AiAgentConfidenceNon    AiAgentConfidence = "none"
 )
 
 var allowedAiAgentConfidenceEnumValues = []AiAgentConfidence{
 	AiAgentConfidenceHigh,
 	AiAgentConfidenceMedium,
 	AiAgentConfidenceLow,
-	AiAgentConfidence,
+	AiAgentConfidenceNon,
 }
 
 // GetAllowedValues returns the list of possible values.

--- a/api/kbcloud/model_ai_agent_recover_action_type.go
+++ b/api/kbcloud/model_ai_agent_recover_action_type.go
@@ -21,7 +21,7 @@ const (
 	AiAgentRecoverActionTypeViewReport            AiAgentRecoverActionType = "view_report"
 	AiAgentRecoverActionTypeRegenerateReport      AiAgentRecoverActionType = "regenerate_report"
 	AiAgentRecoverActionTypeContinueInvestigation AiAgentRecoverActionType = "continue_investigation"
-	AiAgentRecoverActionType                      AiAgentRecoverActionType = "none"
+	AiAgentRecoverActionTypeNon                   AiAgentRecoverActionType = "none"
 )
 
 var allowedAiAgentRecoverActionTypeEnumValues = []AiAgentRecoverActionType{
@@ -32,7 +32,7 @@ var allowedAiAgentRecoverActionTypeEnumValues = []AiAgentRecoverActionType{
 	AiAgentRecoverActionTypeViewReport,
 	AiAgentRecoverActionTypeRegenerateReport,
 	AiAgentRecoverActionTypeContinueInvestigation,
-	AiAgentRecoverActionType,
+	AiAgentRecoverActionTypeNon,
 }
 
 // GetAllowedValues returns the list of possible values.

--- a/api/kbcloud/model_ai_agent_root_cause_type.go
+++ b/api/kbcloud/model_ai_agent_root_cause_type.go
@@ -16,13 +16,13 @@ type AiAgentRootCauseType string
 const (
 	AiAgentRootCauseTypeConfirmed AiAgentRootCauseType = "confirmed"
 	AiAgentRootCauseTypeCandidate AiAgentRootCauseType = "candidate"
-	AiAgentRootCauseType          AiAgentRootCauseType = "none"
+	AiAgentRootCauseTypeNon       AiAgentRootCauseType = "none"
 )
 
 var allowedAiAgentRootCauseTypeEnumValues = []AiAgentRootCauseType{
 	AiAgentRootCauseTypeConfirmed,
 	AiAgentRootCauseTypeCandidate,
-	AiAgentRootCauseType,
+	AiAgentRootCauseTypeNon,
 }
 
 // GetAllowedValues returns the list of possible values.


### PR DESCRIPTION
## Summary
- Rebased this PR onto latest `origin/main`.
- Re-bundled OpenAPI schemas from `~/apecloud` main (`13ad858427`) with Redocly and regenerated Go SDK with `./generate.sh`.
- The refreshed schemas/generated output match the current `kb-cloud-client-go` generated files; this PR now only carries the generator fixes and the affected generated files for issue #69.
- Fix generator enum constant naming so lowercase `none` values use the existing `Non` suffix path instead of colliding with the enum type name.
- Avoid generating unused `localVarBody` reads for no-return/no-error-model API methods.

Fixes #69

## Verification
- `redocly bundle ./api/openapi.yaml > /tmp/kbcloud-openapi-main.yaml` from `~/apecloud/apiserver`
- `redocly bundle ./api/adminapi.yaml > /tmp/kbcloud-adminapi-main.yaml` from `~/apecloud/apiserver`
- `./generate.sh`
- `go test ./api/...`
