### PR TITLE
fix: support multipart form fields in generator

### DIFF
--- a/.generator/src/generator/openapi.py
+++ b/.generator/src/generator/openapi.py
@@ -338,13 +338,14 @@ def parameters(operation):
 def form_parameter(operation):
     if "requestBody" in operation and "multipart/form-data" in operation["requestBody"]["content"]:
         parent = operation["requestBody"]["content"]["multipart/form-data"]["schema"]
-        [(name, schema)] = list(parent["properties"].items())
-        return {
-            "schema": schema,
-            "name": name,
-            "description": schema.get("description"),
-            "required": name in parent.get("required", []),
-        }
+        for name, schema in parent["properties"].items():
+            if schema.get("format") == "binary":
+                return {
+                    "schema": schema,
+                    "name": name,
+                    "description": schema.get("description"),
+                    "required": name in parent.get("required", []),
+                }
 
 
 def need_body_parameter(operation):

--- a/.generator/src/generator/templates/api.j2
+++ b/.generator/src/generator/templates/api.j2
@@ -222,9 +222,18 @@ localVarQueryParams.Add("{{ parameter.name }}", {{ common_package_name }}.Parame
 	{%- endif %}
 	{%- endfor %}
 
+	{%- for name, parameter in operation|parameters if parameter.in == "form" and not (parameter.schema.format is defined and parameter.schema.format == "binary") %}
+	{%- if parameter.required %}
+	localVarFormParams.Add("{{ parameter.name }}", {{ common_package_name }}.ParameterToString({{ name|variable_name}}, "{{ parameter|collection_format }}"))
+	{%- else %}
+	if optionalParams.{{ name|attribute_name }} != nil {
+		localVarFormParams.Add("{{ parameter.name }}", {{ common_package_name }}.ParameterToString(*optionalParams.{{ name|attribute_name }}, "{{ parameter|collection_format }}"))
+	}
+	{%- endif %}
+	{%- endfor %}
+
 	{%- if formParameter %}
-    formFile := {{ common_package_name }}.FormFile{}
-	formFile.FormFileName = "{{ formParameter.name }}"
+	var formFile *{{ common_package_name }}.FormFile
 	{%- if formParameter.required %}
 	localVarFile := {{ formParameter.name|variable_name}}
 	{%- else %}
@@ -235,7 +244,10 @@ localVarQueryParams.Add("{{ parameter.name }}", {{ common_package_name }}.Parame
 	{%- endif %}
 	if localVarFile != nil {
 		fbs, _ := _io.ReadAll(localVarFile)
-		formFile.FileBytes = fbs
+		formFile = &{{ common_package_name }}.FormFile{
+			FormFileName: "{{ formParameter.name }}",
+			FileBytes: fbs,
+		}
 	}
     {% if needBodyParameter %}
     localVarFormParams, err = {{ common_package_name }}.BuildFormParams({{ operation.get("x-codegen-request-body-name", "body")|variable_name }})
@@ -273,7 +285,7 @@ localVarQueryParams.Add("{{ parameter.name }}", {{ common_package_name }}.Parame
 	{%- endfor %}
 	)
 	{%- endif %}
-	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, {% if formParameter %}&formFile{% else %}nil{% endif %})
+	req, err := a.Client.PrepareRequest(ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, {% if formParameter %}formFile{% else %}nil{% endif %})
 	if err != nil {
 		return {% if returnType %}localVarReturnValue, {% endif %}nil, err
 	}


### PR DESCRIPTION
This unblocks apecloud/apecloud#17613 check-client-go.\n\nThe current generator assumes a multipart/form-data schema has exactly one property, but the admin engineLicense API has multiple regular form fields plus a binary licenseFile. This patch makes form_parameter select the binary field and emits non-binary multipart fields as form params.\n\nValidated locally by regenerating client code from the ApeCloud PR bundled OpenAPI specs; generation no longer fails on createEngineLicense.