### PR TITLE
fix: avoid generated HasDetail name conflict

### DIFF
--- a/.generator/src/generator/cli.py
+++ b/.generator/src/generator/cli.py
@@ -39,6 +39,7 @@ def cli(specs, output):
     env.filters["is_primitive"] = formatter.is_primitive
     env.filters["parameter_schema"] = openapi.parameter_schema
     env.filters["parameters"] = openapi.parameters
+    env.filters["presence_method_name"] = formatter.presence_method_name
     env.filters["form_parameter"] = openapi.form_parameter
     env.filters["need_body_parameter"] = openapi.need_body_parameter
     env.filters["response_type"] = openapi.get_type_for_response

--- a/.generator/src/generator/formatter.py
+++ b/.generator/src/generator/formatter.py
@@ -103,6 +103,30 @@ def attribute_name(attribute):
     return escape_reserved_keyword(camel_case(attribute))
 
 
+def _model_property_names(model):
+    names = set()
+    for attr in model.get("properties", {}):
+        names.add(attribute_name(attr))
+
+    for subschema in model.get("allOf", []):
+        for attr in subschema.get("properties", {}):
+            names.add(attribute_name(attr))
+
+    return names
+
+
+def presence_method_name(model, attribute):
+    name = f"Has{attribute_name(attribute)}"
+    property_names = _model_property_names(model)
+    if name not in property_names:
+        return name
+
+    candidate = f"{name}Set"
+    while candidate in property_names:
+        candidate += "Set"
+    return candidate
+
+
 def variable_name(attribute):
     return escape_reserved_keyword(untitle_case(camel_case(attribute)))
 

--- a/.generator/src/generator/templates/model_allof.j2
+++ b/.generator/src/generator/templates/model_allof.j2
@@ -168,8 +168,8 @@ func (o *{{ name }}) Get{{ propertyName }}Ok() (*{{ baseType }}, bool) {
 {%- endif %}
 }
 
-// Has{{ propertyName }} returns a boolean if a field has been set.
-func (o *{{ name }}) Has{{ propertyName }}() bool {
+// {{ model|presence_method_name(attr) }} returns a boolean if a field has been set.
+func (o *{{ name }}) {{ model|presence_method_name(attr) }}() bool {
     return o != nil && {% if not isNullable %}o.{{ propertyName }} != nil{%- else %}{%- if (isContainer and not isPrimitiveContainer) or isAdditionalPropertiesContainer %}o.{{ propertyName }} != nil{%- else %}o.{{ propertyName }}.IsSet(){%- endif %}{%- endif %}
 }
 

--- a/.generator/src/generator/templates/model_simple.j2
+++ b/.generator/src/generator/templates/model_simple.j2
@@ -212,8 +212,8 @@ func (o *{{ name }}) Get{{ propertyName }}Ok() (*{{ baseType }}, bool) {
 {%- endif %}
 }
 
-// Has{{ propertyName }} returns a boolean if a field has been set.
-func (o *{{ name }}) Has{{ propertyName }}() bool {
+// {{ model|presence_method_name(attr) }} returns a boolean if a field has been set.
+func (o *{{ name }}) {{ model|presence_method_name(attr) }}() bool {
 	return o != nil && {% if not isNullable %}o.{{ propertyName }} != nil{%- else %}{%- if (isContainer and not isPrimitiveContainer) or isAdditionalPropertiesContainer %}o.{{ propertyName }} != nil{%- else %}o.{{ propertyName }}.IsSet(){%- endif %}{%- endif %}
 }
 

--- a/.generator/tests/test_formatter.py
+++ b/.generator/tests/test_formatter.py
@@ -1,0 +1,42 @@
+from generator.formatter import presence_method_name
+
+
+def test_presence_method_name_keeps_default_when_no_property_conflict():
+    model = {
+        "properties": {
+            "detail": {},
+            "title": {},
+        }
+    }
+
+    assert presence_method_name(model, "detail") == "HasDetail"
+
+
+def test_presence_method_name_avoids_conflicting_property_name():
+    model = {
+        "properties": {
+            "hasDetail": {},
+            "detail": {},
+        }
+    }
+
+    assert presence_method_name(model, "detail") == "HasDetailSet"
+
+
+def test_presence_method_name_checks_allof_properties():
+    model = {
+        "allOf": [
+            {
+                "properties": {
+                    "hasDetail": {},
+                }
+            },
+            {
+                "properties": {
+                    "detail": {},
+                }
+            },
+        ]
+    }
+
+    assert presence_method_name(model, "detail") == "HasDetailSet"

--- a/api/kbcloud/admin/model_ai_agent_turn_action.go
+++ b/api/kbcloud/admin/model_ai_agent_turn_action.go
@@ -379,8 +379,8 @@ func (o *AiAgentTurnAction) GetDetailOk() (*map[string]interface{}, bool) {
 	return &o.Detail, true
 }
 
-// HasDetail returns a boolean if a field has been set.
-func (o *AiAgentTurnAction) HasDetail() bool {
+// HasDetailSet returns a boolean if a field has been set.
+func (o *AiAgentTurnAction) HasDetailSet() bool {
 	return o != nil && o.Detail != nil
 }
 

--- a/api/kbcloud/model_ai_agent_turn_action.go
+++ b/api/kbcloud/model_ai_agent_turn_action.go
@@ -379,8 +379,8 @@ func (o *AiAgentTurnAction) GetDetailOk() (*map[string]interface{}, bool) {
 	return &o.Detail, true
 }
 
-// HasDetail returns a boolean if a field has been set.
-func (o *AiAgentTurnAction) HasDetail() bool {
+// HasDetailSet returns a boolean if a field has been set.
+func (o *AiAgentTurnAction) HasDetailSet() bool {
 	return o != nil && o.Detail != nil
 }
 


### PR DESCRIPTION
## Summary

Fix the generated Go client name conflict reported in apecloud/apecloud#18730.

The latest generated `AiAgentTurnAction` model contains a required JSON field named `hasDetail`, which maps to a Go struct field named `HasDetail`. The same model also has an optional `detail` field, and the generator emits a presence helper named `HasDetail()` for optional fields. Go does not allow a struct field and method to share the same name, so the generated client failed to compile.

## Changes

- Add a generator helper that detects when an optional field's `Has<Field>()` presence method would collide with an existing generated struct field.
- Use `Has<Field>Set()` only for the collision case, preserving the existing `Has<Field>()` method name everywhere else.
- Regenerate the affected `AiAgentTurnAction` public and admin models so the `detail` presence helper becomes `HasDetailSet()` while the JSON/API fields remain unchanged.
- Add pytest coverage for normal properties, direct conflicts, and `allOf` property conflicts.

## Validation

- `./generate.sh`
- `poetry run pytest tests/test_formatter.py`
- `go test ./...`

Fixes apecloud/apecloud#18730
