### PR TITLE
fix: avoid ai agent hasDetail helper collision

### DIFF
--- a/api/kbcloud/admin/model_ai_agent_turn_action.go
+++ b/api/kbcloud/admin/model_ai_agent_turn_action.go
@@ -386,8 +386,8 @@ func (o *AiAgentTurnAction) GetDetailOk() (*map[string]interface{}, bool) {
 	return &o.Detail, true
 }
 
-// HasDetail returns a boolean if a field has been set.
-func (o *AiAgentTurnAction) HasDetail() bool {
+// HasDetailValue returns a boolean if the Detail field has been set.
+func (o *AiAgentTurnAction) HasDetailValue() bool {
 	return o != nil && o.Detail != nil
 }
 

--- a/api/kbcloud/model_ai_agent_turn_action.go
+++ b/api/kbcloud/model_ai_agent_turn_action.go
@@ -386,8 +386,8 @@ func (o *AiAgentTurnAction) GetDetailOk() (*map[string]interface{}, bool) {
 	return &o.Detail, true
 }
 
-// HasDetail returns a boolean if a field has been set.
-func (o *AiAgentTurnAction) HasDetail() bool {
+// HasDetailValue returns a boolean if the Detail field has been set.
+func (o *AiAgentTurnAction) HasDetailValue() bool {
 	return o != nil && o.Detail != nil
 }
 


### PR DESCRIPTION
## Problem

The current `release-2.2` generated client does not compile after the latest API generation. `AiAgentTurnAction` contains both:

- a required field `HasDetail bool` for JSON `hasDetail`
- a generated optional-field helper method `HasDetail()` for JSON `detail`

Go rejects the field/method name collision, so downstream `go test` fails before it can use the release-2.2 client.

## Fix

Keep the required `HasDetail` field and its existing getter/setter intact. Rename only the optional `detail` presence helper to `HasDetailValue()` in both public and admin generated models.

## Validation

- `go test ./...`
- `git diff --check`
