### PR TITLE
fix: align AI agent detail helper with main

### DIFF
--- a/api/kbcloud/admin/model_ai_agent_turn_action.go
+++ b/api/kbcloud/admin/model_ai_agent_turn_action.go
@@ -386,8 +386,8 @@ func (o *AiAgentTurnAction) GetDetailOk() (*map[string]interface{}, bool) {
 	return &o.Detail, true
 }
 
-// HasDetailValue returns a boolean if the Detail field has been set.
-func (o *AiAgentTurnAction) HasDetailValue() bool {
+// HasDetailSet returns a boolean if a field has been set.
+func (o *AiAgentTurnAction) HasDetailSet() bool {
 	return o != nil && o.Detail != nil
 }
 

--- a/api/kbcloud/model_ai_agent_turn_action.go
+++ b/api/kbcloud/model_ai_agent_turn_action.go
@@ -386,8 +386,8 @@ func (o *AiAgentTurnAction) GetDetailOk() (*map[string]interface{}, bool) {
 	return &o.Detail, true
 }
 
-// HasDetailValue returns a boolean if the Detail field has been set.
-func (o *AiAgentTurnAction) HasDetailValue() bool {
+// HasDetailSet returns a boolean if a field has been set.
+func (o *AiAgentTurnAction) HasDetailSet() bool {
 	return o != nil && o.Detail != nil
 }
 


### PR DESCRIPTION
## Summary
- follow up #73 by renaming the optional detail presence helper from HasDetailValue() to HasDetailSet()
- match the current main branch generated-client naming while keeping the required hasDetail field contract unchanged

## Validation
- go test ./...
- git diff --check